### PR TITLE
feat: ensure goose acp process runs in user home directory

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -56,8 +56,13 @@ class GooseACPClient:
         print(f"[{datetime.now()}] Starting Goose ACP process...")
         cmd = ["goose", "acp"]
         if self.linux_user:
-            cmd = ["sudo", "-n", "-u", self.linux_user] + cmd
-            
+            import pwd
+            try:
+                home_dir = pwd.getpwnam(self.linux_user).pw_dir
+                cmd = ["sudo", "-n", "-u", self.linux_user, "-D", home_dir] + cmd
+            except KeyError:
+                cmd = ["sudo", "-n", "-u", self.linux_user] + cmd
+
         self.process = await asyncio.create_subprocess_exec(
             *cmd,
             stdin=asyncio.subprocess.PIPE,


### PR DESCRIPTION
When launching the  process via  for a specific Linux user, the process was inheriting the working directory of the bridge process. This change ensures that the  process starts in the home directory of the target Linux user by using the  flag with . This provides a clean and expected environment for each user's goose session.

Key changes:
- Retrieve the home directory for the target user using the /home/goose/goose-mm-bridge module.
- Add  to the  command when starting the Goose ACP process.
- Fallback to default  behavior if the user cannot be found in the password database.