### PR TITLE
Improve Test Coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 pytest
 pytest-asyncio
 pytest-mock
+hypothesis

--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -324,6 +324,8 @@ class GooseACPClient:
 
     async def _drain_remaining_chunks(self, session_id: str, full_response: str) -> str:
         """Drains any remaining chunks from the session queue after the final response."""
+        if session_id not in self.session_queues:
+            return full_response
         while not self.session_queues[session_id].empty():
             chunk = await self.session_queues[session_id].get()
             if self.config.debug:

--- a/tests/test_goose_acp_client.py
+++ b/tests/test_goose_acp_client.py
@@ -132,3 +132,52 @@ async def test_rpc_timeout(client):
         
         assert client._healthy is False
         assert mock_process.terminate.called
+
+@pytest.mark.asyncio
+async def test_large_message_handling(client):
+    mock_process = MagicMock()
+    mock_process.returncode = None
+    # Create a large response (~1MB)
+    large_text = "a" * (1024 * 1024)
+    large_json = json.dumps({"id": 1, "result": {"data": large_text}}) + "\n"
+    
+    # Mock stdout to return this large line
+    mock_process.stdout.readline = AsyncMock(side_effect=[large_json.encode(), b""])
+    mock_process.stdout.at_eof = MagicMock(side_effect=[False, True])
+    client.process = mock_process
+    
+    future = asyncio.Future()
+    client.pending_requests[1] = future
+    
+    # Start the reader task
+    reader = asyncio.create_task(client._read_stdout())
+    
+    # Wait for the future to be resolved by the reader
+    res = await asyncio.wait_for(future, timeout=2)
+    assert res["result"]["data"] == large_text
+    await reader
+
+@pytest.mark.asyncio
+async def test_drain_remaining_chunks_unit(client):
+    session_id = "session_123"
+    client.session_queues[session_id] = asyncio.Queue()
+    
+    # Put some late chunks in
+    await client.session_queues[session_id].put({
+        "method": "session/prompt/next",
+        "params": {"chunk": {"type": "text", "text": "late "}}
+    })
+    await client.session_queues[session_id].put({
+        "method": "session/prompt/next",
+        "params": {"chunk": {"type": "text", "text": "data"}}
+    })
+    
+    final_res = await client._drain_remaining_chunks(session_id, "initial ")
+    assert final_res == "initial late data"
+    assert client.session_queues[session_id].empty()
+
+@pytest.mark.asyncio
+async def test_drain_missing_session(client):
+    # Verify the fix for KeyError when session is gone
+    res = await client._drain_remaining_chunks("missing", "test")
+    assert res == "test"

--- a/tests/test_goose_acp_client.py
+++ b/tests/test_goose_acp_client.py
@@ -113,3 +113,21 @@ async def test_process_death_during_prompt(client):
     # The loop should check this and raise RuntimeError
     with pytest.raises(RuntimeError, match="Goose ACP process terminated during prompt"):
         await task
+@pytest.mark.asyncio
+async def test_rpc_timeout(client):
+    mock_process = MagicMock()
+    mock_process.returncode = None
+    mock_process.stdin = MagicMock()
+    mock_process.stdin.drain = AsyncMock()
+    mock_process.terminate = MagicMock()
+    client.process = mock_process
+    
+    # Mock _send_raw_request to never complete
+    with patch.object(client, '_send_raw_request', new_callable=AsyncMock) as mock_raw:
+        mock_raw.side_effect = asyncio.TimeoutError()
+        
+        with pytest.raises(asyncio.TimeoutError):
+            await client.send_request("test", timeout=0.1)
+        
+        assert client._healthy is False
+        assert mock_process.terminate.called

--- a/tests/test_goose_acp_client.py
+++ b/tests/test_goose_acp_client.py
@@ -82,3 +82,34 @@ async def test_parse_update_chunk(client):
     parsed = client._parse_update_chunk(chunk)
     assert parsed["type"] == "tool"
     assert parsed["name"] == "test_tool"
+
+@pytest.mark.asyncio
+async def test_process_death_during_prompt(client):
+    mock_process = MagicMock()
+    mock_process.returncode = None
+    client.process = mock_process
+    client.session_queues["session_1"] = asyncio.Queue()
+    
+    # Mock send_request to return a future that won't complete immediately
+    prompt_done_future = asyncio.Future()
+    
+    async def mock_send_request(*args, **kwargs):
+        return await prompt_done_future
+        
+    client.send_request = mock_send_request
+    
+    async def run_prompt():
+        async for _ in client.prompt("session_1", "hello"):
+            pass
+            
+    task = asyncio.create_task(run_prompt())
+    
+    # Give it a moment to enter the loop
+    await asyncio.sleep(0.05)
+    
+    # Now kill the process
+    mock_process.returncode = 1
+    
+    # The loop should check this and raise RuntimeError
+    with pytest.raises(RuntimeError, match="Goose ACP process terminated during prompt"):
+        await task

--- a/tests/test_goose_acp_client.py
+++ b/tests/test_goose_acp_client.py
@@ -113,6 +113,7 @@ async def test_process_death_during_prompt(client):
     # The loop should check this and raise RuntimeError
     with pytest.raises(RuntimeError, match="Goose ACP process terminated during prompt"):
         await task
+
 @pytest.mark.asyncio
 async def test_rpc_timeout(client):
     mock_process = MagicMock()

--- a/tests/test_mattermost_api.py
+++ b/tests/test_mattermost_api.py
@@ -35,6 +35,7 @@ async def test_create_post(api):
         req = args[0]
         assert req.get_full_url() == "https://example.com:443/api/v4/posts"
         assert req.get_method() == "POST"
+
 @pytest.mark.asyncio
 async def test_api_http_error(api):
     with patch('urllib.request.urlopen') as mock_url:

--- a/tests/test_mattermost_api.py
+++ b/tests/test_mattermost_api.py
@@ -1,3 +1,4 @@
+import urllib.error
 import pytest
 from unittest.mock import patch, MagicMock
 from mattermost_api import MattermostAPI
@@ -34,3 +35,11 @@ async def test_create_post(api):
         req = args[0]
         assert req.get_full_url() == "https://example.com:443/api/v4/posts"
         assert req.get_method() == "POST"
+@pytest.mark.asyncio
+async def test_api_http_error(api):
+    with patch('urllib.request.urlopen') as mock_url:
+        mock_error = urllib.error.HTTPError("url", 500, "Internal Server Error", {}, None)
+        mock_url.side_effect = mock_error
+        
+        res = await api.get_me()
+        assert res is None

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -105,3 +105,52 @@ async def test_handle_stop_command(config, mock_api, mock_goose_client):
         assert mock_goose_client.cancel_prompt.called
         assert mock_api.create_post.called
         assert "cancelled" in mock_api.create_post.call_args[0][1]
+@pytest.mark.asyncio
+async def test_ignore_own_messages(config, mock_api):
+    bridge = MattermostBridge(api=mock_api, config=config)
+    bridge.bot_id = "bot_id"
+    
+    post = {"user_id": "bot_id", "message": "hello"}
+    # Should return early
+    await bridge._process_post(post, {})
+    assert not mock_api.get_user.called
+
+@pytest.mark.asyncio
+async def test_require_user_mapping(config, mock_api):
+    config.require_user_mapping = True
+    config.approved_users = []
+    bridge = MattermostBridge(api=mock_api, config=config)
+    bridge.bot_mention = "@bot"
+    
+    post = {
+        "id": "p1", "user_id": "u1", "channel_id": "c1", "message": "@bot hello"
+    }
+    
+    with patch('mattermost_bridge.load_user_mapping', return_value={}):
+        await bridge._process_post(post, {"c1": {"type": "D"}})
+        # Should post a warning to MM
+        assert mock_api.create_post.called
+        assert "isolation profile" in mock_api.create_post.call_args[0][1]
+
+@pytest.mark.asyncio
+async def test_concurrency_locking(config, mock_api, mock_goose_client):
+    bridge = MattermostBridge(api=mock_api, config=config, goose_client_factory=lambda u: mock_goose_client)
+    bridge.bot_mention = "@bot"
+    
+    # Mock a slow prompt to test locking
+    async def slow_prompt(*args):
+        await asyncio.sleep(0.2)
+        yield {"type": "final", "text": "done"}
+    mock_goose_client.prompt = slow_prompt
+    
+    post = {"id": "p1", "user_id": "u1", "channel_id": "c1", "message": "@bot hello"}
+    
+    with patch('mattermost_bridge.load_user_mapping', return_value={"u1": "linux1"}):
+        # Start two tasks for the same thread
+        t1 = asyncio.create_task(bridge._handle_message(post, "linux1"))
+        t2 = asyncio.create_task(bridge._handle_message(post, "linux1"))
+        
+        await asyncio.gather(t1, t2)
+        
+        # Verify they shared the same lock
+        assert "u1:p1" in bridge.session_locks

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -155,3 +155,52 @@ async def test_concurrency_locking(config, mock_api, mock_goose_client):
         
         # Verify they shared the same lock
         assert "u1:p1" in bridge.session_locks
+
+@pytest.mark.asyncio
+async def test_polling_loop_recovery(config, mock_api):
+    # We'll mock _update_channel_cache to fail once then succeed
+    bridge = MattermostBridge(api=mock_api, config=config)
+    
+    call_count = 0
+    original_update = bridge._update_channel_cache
+    
+    async def mock_update():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise Exception("Transient Error")
+        return await original_update()
+
+    bridge._update_channel_cache = mock_update
+    
+    # Use a small poll interval and mock sleep to exit quickly
+    config.poll_interval = 0.01
+    
+    with patch('asyncio.sleep', side_effect=[None, KeyboardInterrupt()]):
+        await bridge.run()
+    
+    assert call_count >= 2
+    print(f"Loop recovered after {call_count} calls")
+
+@pytest.mark.asyncio
+async def test_user_mapping_edge_cases(config, mock_api):
+    bridge = MattermostBridge(api=mock_api, config=config)
+    bridge.bot_mention = "@bot"
+    
+    # Case 1: Approved user but no mapping
+    config.approved_users = ["user1"]
+    config.require_user_mapping = True
+    post = {"id": "p1", "user_id": "user1", "channel_id": "c1", "message": "@bot hello"}
+    
+    with patch('mattermost_bridge.load_user_mapping', return_value={}):
+        mock_api.get_user = AsyncMock(return_value={"username": "user1"})
+        await bridge._process_post(post, {"c1": {"type": "D"}})
+        assert mock_api.create_post.called
+        assert "isolation profile" in mock_api.create_post.call_args[0][1]
+
+    # Case 2: Not approved user but has mapping (should still be ignored)
+    mock_api.create_post.reset_mock()
+    config.approved_users = ["other_user"]
+    with patch('mattermost_bridge.load_user_mapping', return_value={"user1": "linux1"}):
+        await bridge._process_post(post, {"c1": {"type": "D"}})
+        assert not mock_api.create_post.called

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -105,6 +105,7 @@ async def test_handle_stop_command(config, mock_api, mock_goose_client):
         assert mock_goose_client.cancel_prompt.called
         assert mock_api.create_post.called
         assert "cancelled" in mock_api.create_post.call_args[0][1]
+
 @pytest.mark.asyncio
 async def test_ignore_own_messages(config, mock_api):
     bridge = MattermostBridge(api=mock_api, config=config)

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -63,3 +63,45 @@ async def test_handle_message(config, mock_api, mock_goose_client):
         assert mock_api.create_post.called
         # First post is "Thinking..."
         assert mock_api.create_post.call_args_list[0][0][1] == ":thinking_face: **Thinking...**"
+
+@pytest.mark.asyncio
+async def test_session_pruning(config, mock_api, mock_goose_client):
+    config.max_sessions = 2
+    mock_goose_client.send_request = AsyncMock(return_value={})
+    bridge = MattermostBridge(api=mock_api, config=config, goose_client_factory=lambda u: mock_goose_client)
+    
+    # Fill sessions
+    bridge.sessions = {
+        "user:thread1": {"id": "s1", "linux_user": "u1"},
+        "user:thread2": {"id": "s2", "linux_user": "u1"},
+        "user:thread3": {"id": "s3", "linux_user": "u1"}
+    }
+    bridge.goose_clients["u1"] = mock_goose_client
+    
+    await bridge._prune_sessions()
+    
+    # Should have pruned (max_sessions // 5) = 0, but max(1, ...) = 1
+    assert len(bridge.sessions) == 2
+    assert "user:thread1" not in bridge.sessions
+    assert mock_goose_client.send_request.called
+
+@pytest.mark.asyncio
+async def test_handle_stop_command(config, mock_api, mock_goose_client):
+    mock_goose_client.cancel_prompt = AsyncMock(return_value=True)
+    bridge = MattermostBridge(api=mock_api, config=config, goose_client_factory=lambda u: mock_goose_client)
+    bridge.sessions["user_id_1:root_1"] = {"id": "session_1", "linux_user": "linux_user"}
+    bridge.goose_clients["linux_user"] = mock_goose_client
+    
+    post = {
+        "id": "post_1",
+        "user_id": "user_id_1",
+        "channel_id": "channel_1",
+        "root_id": "root_1",
+        "message": "!stop"
+    }
+    
+    with patch('mattermost_bridge.load_user_mapping', return_value={"user_id_1": "linux_user"}):
+        await bridge._handle_stop_command(post)
+        assert mock_goose_client.cancel_prompt.called
+        assert mock_api.create_post.called
+        assert "cancelled" in mock_api.create_post.call_args[0][1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,23 @@
 from utils import clean_message, get_session_key, load_user_mapping
 import json
 import os
+import pytest
+from hypothesis import given, strategies as st
 
 def test_clean_message():
     assert clean_message("@bot hello", "@bot") == "hello"
     assert clean_message("@bot: hello", "@bot") == "hello"
     assert clean_message("@bot, hello", "@bot") == "hello"
     assert clean_message("just a message", "@bot") == "just a message"
+
+@given(st.text(), st.text(min_size=1))
+def test_clean_message_property(msg, bot_name):
+    # Ensure no crash and basic property: if bot name is in msg, it should be removed
+    # (Simplified property since clean_message has specific logic for prefix punctuation)
+    result = clean_message(msg, bot_name)
+    assert isinstance(result, str)
+    if bot_name in msg and msg.strip().startswith(bot_name):
+        assert bot_name not in result
 
 def test_get_session_key():
     assert get_session_key("user1", "root1") == "user1:root1"


### PR DESCRIPTION
Addresses issue #26 by adding tests for:
- Goose process death during prompt
- Session pruning logic
- Handle !stop command

Also includes a robustness fix in GooseACPClient._drain_remaining_chunks to handle cases where session queues are cleared during process restart.