### PR TITLE
Improve Test Coverage - Part 2

### DIFF
--- a/tests/test_goose_acp_client.py
+++ b/tests/test_goose_acp_client.py
@@ -113,3 +113,21 @@ async def test_process_death_during_prompt(client):
     # The loop should check this and raise RuntimeError
     with pytest.raises(RuntimeError, match="Goose ACP process terminated during prompt"):
         await task
+@pytest.mark.asyncio
+async def test_rpc_timeout(client):
+    mock_process = MagicMock()
+    mock_process.returncode = None
+    mock_process.stdin = MagicMock()
+    mock_process.stdin.drain = AsyncMock()
+    mock_process.terminate = MagicMock()
+    client.process = mock_process
+    
+    # Mock _send_raw_request to never complete
+    with patch.object(client, '_send_raw_request', new_callable=AsyncMock) as mock_raw:
+        mock_raw.side_effect = asyncio.TimeoutError()
+        
+        with pytest.raises(asyncio.TimeoutError):
+            await client.send_request("test", timeout=0.1)
+        
+        assert client._healthy is False
+        assert mock_process.terminate.called

--- a/tests/test_goose_acp_client.py
+++ b/tests/test_goose_acp_client.py
@@ -113,6 +113,7 @@ async def test_process_death_during_prompt(client):
     # The loop should check this and raise RuntimeError
     with pytest.raises(RuntimeError, match="Goose ACP process terminated during prompt"):
         await task
+
 @pytest.mark.asyncio
 async def test_rpc_timeout(client):
     mock_process = MagicMock()

--- a/tests/test_mattermost_api.py
+++ b/tests/test_mattermost_api.py
@@ -35,6 +35,7 @@ async def test_create_post(api):
         req = args[0]
         assert req.get_full_url() == "https://example.com:443/api/v4/posts"
         assert req.get_method() == "POST"
+
 @pytest.mark.asyncio
 async def test_api_http_error(api):
     with patch('urllib.request.urlopen') as mock_url:

--- a/tests/test_mattermost_api.py
+++ b/tests/test_mattermost_api.py
@@ -1,3 +1,4 @@
+import urllib.error
 import pytest
 from unittest.mock import patch, MagicMock
 from mattermost_api import MattermostAPI
@@ -34,3 +35,11 @@ async def test_create_post(api):
         req = args[0]
         assert req.get_full_url() == "https://example.com:443/api/v4/posts"
         assert req.get_method() == "POST"
+@pytest.mark.asyncio
+async def test_api_http_error(api):
+    with patch('urllib.request.urlopen') as mock_url:
+        mock_error = urllib.error.HTTPError("url", 500, "Internal Server Error", {}, None)
+        mock_url.side_effect = mock_error
+        
+        res = await api.get_me()
+        assert res is None

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -105,3 +105,52 @@ async def test_handle_stop_command(config, mock_api, mock_goose_client):
         assert mock_goose_client.cancel_prompt.called
         assert mock_api.create_post.called
         assert "cancelled" in mock_api.create_post.call_args[0][1]
+@pytest.mark.asyncio
+async def test_ignore_own_messages(config, mock_api):
+    bridge = MattermostBridge(api=mock_api, config=config)
+    bridge.bot_id = "bot_id"
+    
+    post = {"user_id": "bot_id", "message": "hello"}
+    # Should return early
+    await bridge._process_post(post, {})
+    assert not mock_api.get_user.called
+
+@pytest.mark.asyncio
+async def test_require_user_mapping(config, mock_api):
+    config.require_user_mapping = True
+    config.approved_users = []
+    bridge = MattermostBridge(api=mock_api, config=config)
+    bridge.bot_mention = "@bot"
+    
+    post = {
+        "id": "p1", "user_id": "u1", "channel_id": "c1", "message": "@bot hello"
+    }
+    
+    with patch('mattermost_bridge.load_user_mapping', return_value={}):
+        await bridge._process_post(post, {"c1": {"type": "D"}})
+        # Should post a warning to MM
+        assert mock_api.create_post.called
+        assert "isolation profile" in mock_api.create_post.call_args[0][1]
+
+@pytest.mark.asyncio
+async def test_concurrency_locking(config, mock_api, mock_goose_client):
+    bridge = MattermostBridge(api=mock_api, config=config, goose_client_factory=lambda u: mock_goose_client)
+    bridge.bot_mention = "@bot"
+    
+    # Mock a slow prompt to test locking
+    async def slow_prompt(*args):
+        await asyncio.sleep(0.2)
+        yield {"type": "final", "text": "done"}
+    mock_goose_client.prompt = slow_prompt
+    
+    post = {"id": "p1", "user_id": "u1", "channel_id": "c1", "message": "@bot hello"}
+    
+    with patch('mattermost_bridge.load_user_mapping', return_value={"u1": "linux1"}):
+        # Start two tasks for the same thread
+        t1 = asyncio.create_task(bridge._handle_message(post, "linux1"))
+        t2 = asyncio.create_task(bridge._handle_message(post, "linux1"))
+        
+        await asyncio.gather(t1, t2)
+        
+        # Verify they shared the same lock
+        assert "u1:p1" in bridge.session_locks

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -105,6 +105,7 @@ async def test_handle_stop_command(config, mock_api, mock_goose_client):
         assert mock_goose_client.cancel_prompt.called
         assert mock_api.create_post.called
         assert "cancelled" in mock_api.create_post.call_args[0][1]
+
 @pytest.mark.asyncio
 async def test_ignore_own_messages(config, mock_api):
     bridge = MattermostBridge(api=mock_api, config=config)


### PR DESCRIPTION
Part 2 of test coverage improvements.

Associates with issue #26.

Includes tests for:
- RPC timeouts and hung processes
- Mattermost API HTTP errors
- Bot loop prevention
- User mapping requirements
- Session concurrency locking