### PR TITLE
feat: integrate MCP server into bridge process

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ pytest
 pytest-asyncio
 pytest-mock
 hypothesis
+mcp
+uvicorn
+starlette

--- a/src/bridge.py
+++ b/src/bridge.py
@@ -1,11 +1,20 @@
 import asyncio
 from mattermost_bridge import MattermostBridge
 from config import default_config
+from mcp_server import MattermostMCPServer
 
 
 async def run_bridge():
     bridge = MattermostBridge(config=default_config)
-    await bridge.run()
+    
+    tasks = [bridge.run()]
+    
+    if default_config.mcp_enabled:
+        mcp = MattermostMCPServer(bridge)
+        tasks.append(mcp.run(default_config.mcp_host, default_config.mcp_port))
+        print(f"Starting MCP server on {default_config.mcp_host}:{default_config.mcp_port}")
+
+    await asyncio.gather(*tasks)
 
 
 if __name__ == "__main__":

--- a/src/config.py
+++ b/src/config.py
@@ -19,6 +19,9 @@ class Config:
     max_sessions: int = int(os.getenv("MAX_SESSIONS", "100"))
     user_mapping_file: str = os.getenv("USER_MAPPING_FILE", "user_mapping.json")
     require_user_mapping: bool = os.getenv("REQUIRE_USER_MAPPING", "false").lower() == "true"
+    mcp_host: str = os.getenv("MCP_HOST", "127.0.0.1")
+    mcp_port: int = int(os.getenv("MCP_PORT", "8000"))
+    mcp_enabled: bool = os.getenv("MCP_ENABLED", "true").lower() == "true"
 
     def __post_init__(self):
         if self.approved_users is None:

--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -196,12 +196,16 @@ class GooseACPClient:
                     print(f"[{datetime.now()}] Error terminating process: {e}")
             raise
 
-    async def create_session(self) -> str:
+    async def create_session(self, system_prompt: Optional[str] = None) -> str:
         """Creates a new session in the Goose ACP."""
-        res = await self.send_request("session/new", {
+        params = {
             "cwd": os.getcwd(),
             "mcpServers": self._get_mcp_servers()
-        })
+        }
+        if system_prompt:
+            params["systemPrompt"] = system_prompt
+            
+        res = await self.send_request("session/new", params)
         if "error" in res:
             raise Exception(f"Failed to create session: {res['error']}")
         session_id = res["result"]["sessionId"]

--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -198,14 +198,12 @@ class GooseACPClient:
                     print(f"[{datetime.now()}] Error terminating process: {e}")
             raise
 
-    async def create_session(self, system_prompt: Optional[str] = None) -> str:
+    async def create_session(self) -> str:
         """Creates a new session in the Goose ACP."""
         params = {
             "cwd": os.getcwd(),
             "mcpServers": self._get_mcp_servers()
         }
-        if system_prompt:
-            params["systemPrompt"] = system_prompt
             
         res = await self.send_request("session/new", params)
         if "error" in res:

--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -72,9 +72,9 @@ class GooseACPClient:
                 "capabilities": {},
                 "clientInfo": {"name": "goose-mm-bridge", "version": "1.0.0"}
             }), timeout=self.config.rpc_timeout)
-            capabilities = res.get("result", {}).get("capabilities", {})
-            self.sse_supported = capabilities.get("mcp", {}).get("sse", False)
-            self.http_supported = capabilities.get("mcp", {}).get("http", False)
+            capabilities = res.get("result", {}).get("agentCapabilities", {})
+            self.sse_supported = capabilities.get("mcpCapabilities", {}).get("sse", False)
+            self.http_supported = capabilities.get("mcpCapabilities", {}).get("http", False)
             print(f"[{datetime.now()}] Goose ACP initialized. SSE support: {self.sse_supported}, HTTP support: {self.http_supported}")
         except Exception as e:
             print(f"[{datetime.now()}] Failed to initialize Goose ACP: {e}")
@@ -200,6 +200,8 @@ class GooseACPClient:
 
     async def create_session(self) -> str:
         """Creates a new session in the Goose ACP."""
+        await self.ensure_running()
+
         params = {
             "cwd": os.getcwd(),
             "mcpServers": self._get_mcp_servers()

--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -18,6 +18,7 @@ class GooseACPClient:
         self.pending_requests: Dict[int, asyncio.Future] = {}
         self.session_queues: Dict[str, asyncio.Queue] = {}
         self.active_prompts: Dict[str, int] = {}
+        self.sse_supported = False
         self.last_id_used = 0
         self._healthy = True
         self._start_lock = asyncio.Lock()
@@ -65,12 +66,14 @@ class GooseACPClient:
         # Handshake
         try:
             # Note: we use _send_raw_request here because send_request calls ensure_running
-            await asyncio.wait_for(self._send_raw_request("initialize", {
+            res = await asyncio.wait_for(self._send_raw_request("initialize", {
                 "protocolVersion": 0,
                 "capabilities": {},
                 "clientInfo": {"name": "goose-mm-bridge", "version": "1.0.0"}
             }), timeout=self.config.rpc_timeout)
-            print(f"[{datetime.now()}] Goose ACP initialized.")
+            capabilities = res.get("result", {}).get("capabilities", {})
+            self.sse_supported = capabilities.get("mcp", {}).get("sse", False)
+            print(f"[{datetime.now()}] Goose ACP initialized. SSE support: {self.sse_supported}")
         except Exception as e:
             print(f"[{datetime.now()}] Failed to initialize Goose ACP: {e}")
             if self.process:
@@ -197,7 +200,7 @@ class GooseACPClient:
         """Creates a new session in the Goose ACP."""
         res = await self.send_request("session/new", {
             "cwd": os.getcwd(),
-            "mcpServers": []
+            "mcpServers": self._get_mcp_servers()
         })
         if "error" in res:
             raise Exception(f"Failed to create session: {res['error']}")
@@ -346,3 +349,12 @@ class GooseACPClient:
             })
             return True
         return False
+    def _get_mcp_servers(self):
+        if not self.config.mcp_enabled or not self.sse_supported:
+            return []
+        
+        return [{
+            "type": "remote",
+            "name": "mattermost-bridge",
+            "url": f"http://{self.config.mcp_host}:{self.config.mcp_port}/mcp/messages"
+        }]

--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -354,11 +354,12 @@ class GooseACPClient:
             return True
         return False
     def _get_mcp_servers(self):
-        if not self.config.mcp_enabled or not self.sse_supported:
+        if not self.config.mcp_enabled:
             return []
         
         return [{
-            "type": "remote",
+            "type": "http",
             "name": "mattermost-bridge",
-            "url": f"http://{self.config.mcp_host}:{self.config.mcp_port}/mcp/messages"
+            "url": f"http://{self.config.mcp_host}:{self.config.mcp_port}/mcp",
+            "headers": []
         }]

--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -19,6 +19,7 @@ class GooseACPClient:
         self.session_queues: Dict[str, asyncio.Queue] = {}
         self.active_prompts: Dict[str, int] = {}
         self.sse_supported = False
+        self.http_supported = False
         self.last_id_used = 0
         self._healthy = True
         self._start_lock = asyncio.Lock()
@@ -73,7 +74,8 @@ class GooseACPClient:
             }), timeout=self.config.rpc_timeout)
             capabilities = res.get("result", {}).get("capabilities", {})
             self.sse_supported = capabilities.get("mcp", {}).get("sse", False)
-            print(f"[{datetime.now()}] Goose ACP initialized. SSE support: {self.sse_supported}")
+            self.http_supported = capabilities.get("mcp", {}).get("http", False)
+            print(f"[{datetime.now()}] Goose ACP initialized. SSE support: {self.sse_supported}, HTTP support: {self.http_supported}")
         except Exception as e:
             print(f"[{datetime.now()}] Failed to initialize Goose ACP: {e}")
             if self.process:
@@ -354,7 +356,7 @@ class GooseACPClient:
             return True
         return False
     def _get_mcp_servers(self):
-        if not self.config.mcp_enabled:
+        if not self.config.mcp_enabled or not self.http_supported:
             return []
         
         return [{

--- a/src/mattermost_api.py
+++ b/src/mattermost_api.py
@@ -62,6 +62,18 @@ class MattermostAPI:
     async def get_channel_posts(self, channel_id: str, since: int) -> Optional[Dict[str, Any]]:
         return await self._request(f"/channels/{channel_id}/posts?since={since}")
 
+    async def get_thread(self, post_id: str) -> Optional[Dict[str, Any]]:
+        return await self._request(f"/posts/{post_id}/thread")
+
+    async def search_posts(self, team_id: str, terms: str) -> Optional[Dict[str, Any]]:
+        return await self._request(f"/teams/{team_id}/posts/search", data={"terms": terms}, method="POST")
+
+    async def search_users(self, term: str) -> Optional[list]:
+        return await self._request("/users/search", data={"term": term}, method="POST")
+
+    async def create_direct_channel(self, user_ids: list) -> Optional[Dict[str, Any]]:
+        return await self._request("/channels/direct", data=user_ids, method="POST")
+
     async def create_post(self, channel_id: str, message: str, root_id: Optional[str] = None, props: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
         data = {"channel_id": channel_id, "message": message, "root_id": root_id}
         if props:

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -191,8 +191,18 @@ class MattermostBridge:
 
                 if session_key not in self.sessions:
                     print(f"[{datetime.now()}] Creating new Goose session for {session_key}")
+                    
+                    # Fetch user info for system prompt
+                    user_info = await self.api.get_user(sender_id)
+                    username = user_info.get("username", "unknown") if user_info else "unknown"
+                    system_prompt = (
+                        f"You are interacting via a Mattermost bridge. Your primary user is @{username} (ID: {sender_id}). "
+                        "While you automatically receive messages directed at you, use get_thread_context to see the full "
+                        "discussion between other participants in this thread/channel."
+                    )
+                    
                     self.sessions[session_key] = {
-                        "id": await goose.create_session(),
+                        "id": await goose.create_session(system_prompt=system_prompt),
                         "linux_user": linux_user,
                     }
 

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -192,17 +192,8 @@ class MattermostBridge:
                 if session_key not in self.sessions:
                     print(f"[{datetime.now()}] Creating new Goose session for {session_key}")
                     
-                    # Fetch user info for system prompt
-                    user_info = await self.api.get_user(sender_id)
-                    username = user_info.get("username", "unknown") if user_info else "unknown"
-                    system_prompt = (
-                        f"You are interacting via a Mattermost bridge. Your primary user is @{username} (ID: {sender_id}). "
-                        "While you automatically receive messages directed at you, use get_thread_context to see the full "
-                        "discussion between other participants in this thread/channel."
-                    )
-                    
                     self.sessions[session_key] = {
-                        "id": await goose.create_session(system_prompt=system_prompt),
+                        "id": await goose.create_session(),
                         "linux_user": linux_user,
                     }
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -54,7 +54,7 @@ class MattermostMCPServer:
                 channels = self.bridge.channels_cache
                 return [{"type": "text", "text": str(channels)}]
             
-            throw ValueError(f"Unknown tool: {name}")
+            raise ValueError(f"Unknown tool: {name}")
 
     async def run(self, host: str, port: int):
         app = Starlette(debug=True)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,122 +1,44 @@
-
 import asyncio
-from mcp.server import Server
-from mcp.server.sse import SseServerTransport
-from starlette.applications import Starlette
-from starlette.routing import Route, Mount
-import uvicorn
-from typing import Any
 import json
+from typing import List, Optional
+from mcp.server.fastmcp import FastMCP
 
 class MattermostMCPServer:
     def __init__(self, bridge):
         self.bridge = bridge
-        self.server = Server("mattermost-bridge-mcp")
-        self.setup_handlers()
+        self.mcp = FastMCP("mattermost-bridge-mcp")
+        self.setup_tools()
 
-    def setup_handlers(self):
-        self.server.list_tools()(self.list_tools)
-        self.server.call_tool()(self.call_tool)
-
-    async def list_tools(self):
-        return [
-            {
-                "name": "send_message",
-                "description": "Send a message to a Mattermost channel",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "channel_id": {"type": "string"},
-                        "message": {"type": "string"},
-                        "root_id": {"type": "string", "description": "Optional thread root ID"}
-                    },
-                    "required": ["channel_id", "message"]
-                }
-            },
-            {
-                "name": "get_channels",
-                "description": "Get list of available channels",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {}
-                }
-            },
-            {
-                "name": "get_thread_context",
-                "description": "Fetch the full history of a thread",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "root_id": {"type": "string", "description": "The ID of the thread root post"}
-                    },
-                    "required": ["root_id"]
-                }
-            },
-            {
-                "name": "search_messages",
-                "description": "Search for messages across Mattermost",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "terms": {"type": "string", "description": "Search terms"}
-                    },
-                    "required": ["terms"]
-                }
-            },
-            {
-                "name": "search_users",
-                "description": "Search for users by name, username, or email",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "term": {"type": "string", "description": "Search term"}
-                    },
-                    "required": ["term"]
-                }
-            },
-            {
-                "name": "get_user_info",
-                "description": "Get detailed profile information for a user",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "user_id": {"type": "string"}
-                    },
-                    "required": ["user_id"]
-                }
-            },
-            {
-                "name": "send_direct_message",
-                "description": "Send a direct message to one or more users",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "usernames": {"type": "array", "items": {"type": "string"}, "description": "List of usernames (with or without @)"},
-                        "message": {"type": "string"}
-                    },
-                    "required": ["usernames", "message"]
-                }
-            }
-        ]
-
-    async def call_tool(self, name: str, arguments: Any):
-        if name == "send_message":
-            channel_id = arguments["channel_id"]
-            message = arguments["message"]
-            root_id = arguments.get("root_id")
+    def setup_tools(self):
+        @self.mcp.tool()
+        async def send_message(channel_id: str, message: str, root_id: Optional[str] = None) -> str:
+            """Send a message to a Mattermost channel.
+            
+            Args:
+                channel_id: The ID of the channel to send the message to.
+                message: The message text.
+                root_id: Optional thread root ID to reply to a specific thread.
+            """
             await self.bridge.api.create_post(channel_id, message, root_id=root_id)
-            return [{"type": "text", "text": "Message sent successfully"}]
-        
-        elif name == "get_channels":
+            return "Message sent successfully"
+
+        @self.mcp.tool()
+        async def get_channels() -> str:
+            """Get list of available channels."""
             await self.bridge._update_channel_cache()
             channels = self.bridge.channels_cache
-            return [{"type": "text", "text": str(channels)}]
+            return json.dumps(channels, indent=2)
 
-        elif name == "get_thread_context":
-            root_id = arguments["root_id"]
+        @self.mcp.tool()
+        async def get_thread_context(root_id: str) -> str:
+            """Fetch the full history of a thread.
+            
+            Args:
+                root_id: The ID of the thread root post.
+            """
             thread = await self.bridge.api.get_thread(root_id)
             if not thread or "posts" not in thread:
-                return [{"type": "text", "text": "Thread not found or empty"}]
+                return "Thread not found or empty"
             
             posts = sorted(thread["posts"].values(), key=lambda x: x["create_at"])
             
@@ -132,13 +54,18 @@ class MattermostMCPServer:
                 username = user_map.get(p["user_id"], "unknown")
                 formatted.append(f"[Sender: @{username}] {p['message']}")
             
-            return [{"type": "text", "text": "\n".join(formatted)}]
+            return "\n".join(formatted)
 
-        elif name == "search_messages":
-            terms = arguments["terms"]
+        @self.mcp.tool()
+        async def search_messages(terms: str) -> str:
+            """Search for messages across Mattermost.
+            
+            Args:
+                terms: Search terms.
+            """
             teams = await self.bridge.api.get_my_teams()
             if not teams:
-                return [{"type": "text", "text": "No teams found to search in"}]
+                return "No teams found to search in"
             
             all_results = []
             for team in teams:
@@ -147,29 +74,43 @@ class MattermostMCPServer:
                     all_results.extend(results["posts"].values())
             
             if not all_results:
-                return [{"type": "text", "text": "No messages found"}]
+                return "No messages found"
             
             all_results.sort(key=lambda x: x["create_at"], reverse=True)
             formatted = []
             for p in all_results[:20]:
                 formatted.append(f"[Post ID: {p['id']}] [Channel ID: {p['channel_id']}] {p['message']}")
             
-            return [{"type": "text", "text": "\n---\n".join(formatted)}]
+            return "\n---\n".join(formatted)
 
-        elif name == "search_users":
-            term = arguments["term"]
-            users = await self.bridge.api.search_users(term)
-            return [{"type": "text", "text": json.dumps(users, indent=2)}]
-
-        elif name == "get_user_info":
-            user_id = arguments["user_id"]
-            user = await self.bridge.api.get_user(user_id)
-            return [{"type": "text", "text": json.dumps(user, indent=2)}]
-
-        elif name == "send_direct_message":
-            usernames = arguments["usernames"]
-            message = arguments["message"]
+        @self.mcp.tool()
+        async def search_users(term: str) -> str:
+            """Search for users by name, username, or email.
             
+            Args:
+                term: Search term.
+            """
+            users = await self.bridge.api.search_users(term)
+            return json.dumps(users, indent=2)
+
+        @self.mcp.tool()
+        async def get_user_info(user_id: str) -> str:
+            """Get detailed profile information for a user.
+            
+            Args:
+                user_id: The ID of the user.
+            """
+            user = await self.bridge.api.get_user(user_id)
+            return json.dumps(user, indent=2)
+
+        @self.mcp.tool()
+        async def send_direct_message(usernames: List[str], message: str) -> str:
+            """Send a direct message to one or more users.
+            
+            Args:
+                usernames: List of usernames (with or without @).
+                message: The message text.
+            """
             user_ids = []
             for uname in usernames:
                 clean_uname = uname[1:] if uname.startswith("@") else uname
@@ -179,7 +120,7 @@ class MattermostMCPServer:
                     user_ids.append(exact["id"])
             
             if not user_ids:
-                return [{"type": "text", "text": "No valid users found to message"}]
+                return "No valid users found to message"
             
             me = await self.bridge.api.get_me()
             if me and me["id"] not in user_ids:
@@ -187,24 +128,13 @@ class MattermostMCPServer:
             
             channel = await self.bridge.api.create_direct_channel(user_ids)
             if not channel:
-                return [{"type": "text", "text": "Failed to create direct channel"}]
+                return "Failed to create direct channel"
             
             await self.bridge.api.create_post(channel["id"], message)
-            return [{"type": "text", "text": f"Direct message sent to channel {channel['id']}"}]
-        
-        raise ValueError(f"Unknown tool: {name}")
+            return f"Direct message sent to channel {channel['id']}"
 
     async def run(self, host: str, port: int):
-        app = Starlette(debug=True)
-        sse = SseServerTransport("/messages")
-
-        async def handle_sse(request):
-            async with sse.connect_sse(request.scope, request.receive, request._send) as (read_stream, write_stream):
-                await self.server.run(read_stream, write_stream, self.server.create_initialization_options())
-
-        app.mount("/mcp", Mount("/messages", handle_sse))
-        app.add_route("/messages", sse.handle_post_message, methods=["POST"])
-
-        config = uvicorn.Config(app, host=host, port=port, log_level="info")
-        server = uvicorn.Server(config)
-        await server.serve()
+        """Run the MCP server using Streamable HTTP transport."""
+        self.mcp.settings.host = host
+        self.mcp.settings.port = port
+        await self.mcp.run_streamable_http_async()

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -14,47 +14,48 @@ class MattermostMCPServer:
         self.setup_handlers()
 
     def setup_handlers(self):
-        @self.server.list_tools()
-        async def list_tools():
-            return [
-                {
-                    "name": "send_message",
-                    "description": "Send a message to a Mattermost channel",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "channel_id": {"type": "string"},
-                            "message": {"type": "string"},
-                            "root_id": {"type": "string", "description": "Optional thread root ID"}
-                        },
-                        "required": ["channel_id", "message"]
-                    }
-                },
-                {
-                    "name": "get_channels",
-                    "description": "Get list of available channels",
-                    "inputSchema": {
-                        "type": "object",
-                        "properties": {}
-                    }
-                }
-            ]
+        self.server.list_tools()(self.list_tools)
+        self.server.call_tool()(self.call_tool)
 
-        @self.server.call_tool()
-        async def call_tool(name: str, arguments: Any):
-            if name == "send_message":
-                channel_id = arguments["channel_id"]
-                message = arguments["message"]
-                root_id = arguments.get("root_id")
-                await self.bridge.api.create_post(channel_id, message, root_id=root_id)
-                return [{"type": "text", "text": "Message sent successfully"}]
-            
-            elif name == "get_channels":
-                await self.bridge._update_channel_cache()
-                channels = self.bridge.channels_cache
-                return [{"type": "text", "text": str(channels)}]
-            
-            raise ValueError(f"Unknown tool: {name}")
+    async def list_tools(self):
+        return [
+            {
+                "name": "send_message",
+                "description": "Send a message to a Mattermost channel",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {"type": "string"},
+                        "message": {"type": "string"},
+                        "root_id": {"type": "string", "description": "Optional thread root ID"}
+                    },
+                    "required": ["channel_id", "message"]
+                }
+            },
+            {
+                "name": "get_channels",
+                "description": "Get list of available channels",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {}
+                }
+            }
+        ]
+
+    async def call_tool(self, name: str, arguments: Any):
+        if name == "send_message":
+            channel_id = arguments["channel_id"]
+            message = arguments["message"]
+            root_id = arguments.get("root_id")
+            await self.bridge.api.create_post(channel_id, message, root_id=root_id)
+            return [{"type": "text", "text": "Message sent successfully"}]
+        
+        elif name == "get_channels":
+            await self.bridge._update_channel_cache()
+            channels = self.bridge.channels_cache
+            return [{"type": "text", "text": str(channels)}]
+        
+        raise ValueError(f"Unknown tool: {name}")
 
     async def run(self, host: str, port: int):
         app = Starlette(debug=True)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -6,6 +6,7 @@ from starlette.applications import Starlette
 from starlette.routing import Route, Mount
 import uvicorn
 from typing import Any
+import json
 
 class MattermostMCPServer:
     def __init__(self, bridge):
@@ -39,6 +40,62 @@ class MattermostMCPServer:
                     "type": "object",
                     "properties": {}
                 }
+            },
+            {
+                "name": "get_thread_context",
+                "description": "Fetch the full history of a thread",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "root_id": {"type": "string", "description": "The ID of the thread root post"}
+                    },
+                    "required": ["root_id"]
+                }
+            },
+            {
+                "name": "search_messages",
+                "description": "Search for messages across Mattermost",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "terms": {"type": "string", "description": "Search terms"}
+                    },
+                    "required": ["terms"]
+                }
+            },
+            {
+                "name": "search_users",
+                "description": "Search for users by name, username, or email",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "term": {"type": "string", "description": "Search term"}
+                    },
+                    "required": ["term"]
+                }
+            },
+            {
+                "name": "get_user_info",
+                "description": "Get detailed profile information for a user",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "user_id": {"type": "string"}
+                    },
+                    "required": ["user_id"]
+                }
+            },
+            {
+                "name": "send_direct_message",
+                "description": "Send a direct message to one or more users",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "usernames": {"type": "array", "items": {"type": "string"}, "description": "List of usernames (with or without @)"},
+                        "message": {"type": "string"}
+                    },
+                    "required": ["usernames", "message"]
+                }
             }
         ]
 
@@ -54,6 +111,86 @@ class MattermostMCPServer:
             await self.bridge._update_channel_cache()
             channels = self.bridge.channels_cache
             return [{"type": "text", "text": str(channels)}]
+
+        elif name == "get_thread_context":
+            root_id = arguments["root_id"]
+            thread = await self.bridge.api.get_thread(root_id)
+            if not thread or "posts" not in thread:
+                return [{"type": "text", "text": "Thread not found or empty"}]
+            
+            posts = sorted(thread["posts"].values(), key=lambda x: x["create_at"])
+            
+            # Fetch usernames for attribution
+            user_ids = list(set(p["user_id"] for p in posts))
+            user_map = {}
+            for uid in user_ids:
+                uinfo = await self.bridge.api.get_user(uid)
+                user_map[uid] = uinfo.get("username", "unknown") if uinfo else "unknown"
+            
+            formatted = []
+            for p in posts:
+                username = user_map.get(p["user_id"], "unknown")
+                formatted.append(f"[Sender: @{username}] {p['message']}")
+            
+            return [{"type": "text", "text": "\n".join(formatted)}]
+
+        elif name == "search_messages":
+            terms = arguments["terms"]
+            teams = await self.bridge.api.get_my_teams()
+            if not teams:
+                return [{"type": "text", "text": "No teams found to search in"}]
+            
+            all_results = []
+            for team in teams:
+                results = await self.bridge.api.search_posts(team["id"], terms)
+                if results and "posts" in results:
+                    all_results.extend(results["posts"].values())
+            
+            if not all_results:
+                return [{"type": "text", "text": "No messages found"}]
+            
+            all_results.sort(key=lambda x: x["create_at"], reverse=True)
+            formatted = []
+            for p in all_results[:20]:
+                formatted.append(f"[Post ID: {p['id']}] [Channel ID: {p['channel_id']}] {p['message']}")
+            
+            return [{"type": "text", "text": "\n---\n".join(formatted)}]
+
+        elif name == "search_users":
+            term = arguments["term"]
+            users = await self.bridge.api.search_users(term)
+            return [{"type": "text", "text": json.dumps(users, indent=2)}]
+
+        elif name == "get_user_info":
+            user_id = arguments["user_id"]
+            user = await self.bridge.api.get_user(user_id)
+            return [{"type": "text", "text": json.dumps(user, indent=2)}]
+
+        elif name == "send_direct_message":
+            usernames = arguments["usernames"]
+            message = arguments["message"]
+            
+            user_ids = []
+            for uname in usernames:
+                clean_uname = uname[1:] if uname.startswith("@") else uname
+                found = await self.bridge.api.search_users(clean_uname)
+                if found:
+                    exact = next((u for u in found if u["username"] == clean_uname), found[0])
+                    user_ids.append(exact["id"])
+            
+            if not user_ids:
+                return [{"type": "text", "text": "No valid users found to message"}]
+            
+            me = await self.bridge.api.get_me()
+            if me and me["id"] not in user_ids:
+                user_ids.append(me["id"])
+            
+            channel = await self.bridge.api.create_direct_channel(user_ids)
+            if not channel:
+                return [{"type": "text", "text": "Failed to create direct channel"}]
+            
+            await self.bridge.api.create_post(channel["id"], message)
+            return [{"type": "text", "text": f"Direct message sent to channel {channel['id']}"}]
         
         raise ValueError(f"Unknown tool: {name}")
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,0 +1,72 @@
+
+import asyncio
+from mcp.server import Server
+from mcp.server.sse import SseServerTransport
+from starlette.applications import Starlette
+from starlette.routing import Route, Mount
+import uvicorn
+from typing import Any
+
+class MattermostMCPServer:
+    def __init__(self, bridge):
+        self.bridge = bridge
+        self.server = Server("mattermost-bridge-mcp")
+        self.setup_handlers()
+
+    def setup_handlers(self):
+        @self.server.list_tools()
+        async def list_tools():
+            return [
+                {
+                    "name": "send_message",
+                    "description": "Send a message to a Mattermost channel",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "channel_id": {"type": "string"},
+                            "message": {"type": "string"},
+                            "root_id": {"type": "string", "description": "Optional thread root ID"}
+                        },
+                        "required": ["channel_id", "message"]
+                    }
+                },
+                {
+                    "name": "get_channels",
+                    "description": "Get list of available channels",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            ]
+
+        @self.server.call_tool()
+        async def call_tool(name: str, arguments: Any):
+            if name == "send_message":
+                channel_id = arguments["channel_id"]
+                message = arguments["message"]
+                root_id = arguments.get("root_id")
+                await self.bridge.api.create_post(channel_id, message, root_id=root_id)
+                return [{"type": "text", "text": "Message sent successfully"}]
+            
+            elif name == "get_channels":
+                await self.bridge._update_channel_cache()
+                channels = self.bridge.channels_cache
+                return [{"type": "text", "text": str(channels)}]
+            
+            throw ValueError(f"Unknown tool: {name}")
+
+    async def run(self, host: str, port: int):
+        app = Starlette(debug=True)
+        sse = SseServerTransport("/messages")
+
+        async def handle_sse(request):
+            async with sse.connect_sse(request.scope, request.receive, request._send) as (read_stream, write_stream):
+                await self.server.run(read_stream, write_stream, self.server.create_initialization_options())
+
+        app.mount("/mcp", Mount("/messages", handle_sse))
+        app.add_route("/messages", sse.handle_post_message, methods=["POST"])
+
+        config = uvicorn.Config(app, host=host, port=port, log_level="info")
+        server = uvicorn.Server(config)
+        await server.serve()

--- a/tests/goose_simulator.py
+++ b/tests/goose_simulator.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+from unittest.mock import MagicMock, AsyncMock
+
+class MockProcess:
+    """Mocks an asyncio subprocess for the Goose ACP client."""
+    def __init__(self):
+        self.stdin = MagicMock()
+        self.stdin.write = MagicMock()
+        self.stdin.drain = AsyncMock(return_value=None)
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        self.returncode = None
+        self.terminate = MagicMock()
+
+    def feed_stdout(self, data: dict):
+        """Feeds a JSON-RPC message into the stdout stream."""
+        line = json.dumps(data) + "\n"
+        self.stdout.feed_data(line.encode())
+
+
+async def simulate_goose_behavior(mock_process: MockProcess, session_id: str = "session_abc", final_text: str = "The answer is 42."):
+    """Simulates a standard Goose ACP interaction sequence."""
+    try:
+        # 1. Handshake response (triggered by initialize)
+        await asyncio.sleep(0.05)
+        mock_process.feed_stdout({
+            "jsonrpc": "2.0", "id": 1, 
+            "result": {"capabilities": {"mcp": {"sse": True}}}
+        })
+        
+        # 2. session/new response
+        await asyncio.sleep(0.05)
+        mock_process.feed_stdout({
+            "jsonrpc": "2.0", "id": 2, 
+            "result": {"sessionId": session_id}
+        })
+        
+        # 3. session/prompt chunks
+        await asyncio.sleep(0.05)
+        # Thinking chunk
+        mock_process.feed_stdout({
+            "jsonrpc": "2.0", "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {"sessionUpdate": "agent_thinking_chunk", "thinking": "Analyzing..."}
+            }
+        })
+        # Content chunk
+        mock_process.feed_stdout({
+            "jsonrpc": "2.0", "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": final_text}}
+            }
+        })
+        # Final response
+        mock_process.feed_stdout({
+            "jsonrpc": "2.0", "id": 3, 
+            "result": {"status": "completed"}
+        })
+    except Exception as e:
+        print(f"Simulator Error: {e}")

--- a/tests/test_goose_acp_client.py
+++ b/tests/test_goose_acp_client.py
@@ -177,7 +177,25 @@ async def test_drain_remaining_chunks_unit(client):
     assert client.session_queues[session_id].empty()
 
 @pytest.mark.asyncio
-async def test_drain_missing_session(client):
-    # Verify the fix for KeyError when session is gone
-    res = await client._drain_remaining_chunks("missing", "test")
-    assert res == "test"
+async def test_get_mcp_servers(client):
+    client.config.mcp_enabled = True
+    client.config.mcp_host = "localhost"
+    client.config.mcp_port = 5006
+    
+    # Test with HTTP support
+    client.http_supported = True
+    servers = client._get_mcp_servers()
+    assert len(servers) == 1
+    assert servers[0]["type"] == "http"
+    assert "5006/mcp" in servers[0]["url"]
+    
+    # Test without HTTP support
+    client.http_supported = False
+    servers = client._get_mcp_servers()
+    assert len(servers) == 0
+
+    # Test with HTTP support but disabled
+    client.http_supported = True
+    client.config.mcp_enabled = False
+    servers = client._get_mcp_servers()
+    assert len(servers) == 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,11 +1,27 @@
 import pytest
 import asyncio
+import json
 from unittest.mock import MagicMock, AsyncMock, patch
 from mattermost_bridge import MattermostBridge
+from goose_acp_client import GooseACPClient
 from config import Config
 
+class MockProcess:
+    def __init__(self):
+        self.stdin = MagicMock()
+        self.stdin.write = MagicMock()
+        self.stdin.drain = AsyncMock(return_value=None)
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        self.returncode = None
+        self.terminate = MagicMock()
+
+    def feed_stdout(self, data: dict):
+        line = json.dumps(data) + "\n"
+        self.stdout.feed_data(line.encode())
+
 @pytest.mark.asyncio
-async def test_bridge_integration_flow():
+async def test_bridge_integration_flow_with_goose_process():
     # 1. Setup Mock Config
     config = Config(
         mattermost_url="http://mattermost.example.com",
@@ -18,16 +34,12 @@ async def test_bridge_integration_flow():
 
     # 2. Mock Mattermost API
     mock_api = MagicMock()
-    # Mock initialization calls
     mock_api.get_me = AsyncMock(return_value={"id": "bot_id", "username": "goose-bot"})
     mock_api.get_direct_channels = AsyncMock(return_value=[])
     mock_api.get_my_teams = AsyncMock(return_value=[{"id": "team_1"}])
     mock_api.get_my_channels = AsyncMock(return_value=[{"id": "chan_1", "type": "O"}])
-    
-    # Mock user info
     mock_api.get_user = AsyncMock(return_value={"id": "user_1", "username": "alice"})
     
-    # Mock post fetching - first call returns a post, subsequent calls return nothing
     test_post = {
         "id": "post_123",
         "user_id": "user_1",
@@ -36,113 +48,124 @@ async def test_bridge_integration_flow():
         "create_at": 1000
     }
     
-    # Track calls to simulate a single loop iteration
     call_tracker = {"get_posts_count": 0}
-    
     async def side_effect_get_posts(channel_id, since):
-        # The bridge polls all channels in the cache. 
-        # In this test, there's only 'chan_1'.
         if call_tracker["get_posts_count"] == 0:
             call_tracker["get_posts_count"] += 1
-            # Note: The bridge sorts posts by create_at and then calls _process_post
             return {"posts": {"post_123": test_post}, "order": ["post_123"]}
         return {"posts": {}, "order": []}
 
     mock_api.get_channel_posts = AsyncMock(side_effect=side_effect_get_posts)
+    mock_api.create_post = AsyncMock(return_value={"id": "bot_post_456"})
     
-    # Mock post creation and updates
-    created_post = {"id": "bot_post_456"}
-    mock_api.create_post = AsyncMock(return_value=created_post)
-    mock_api.update_post = AsyncMock(return_value=created_post)
+    # Event to signal when the final response is posted to Mattermost
+    final_response_posted = asyncio.Event()
+    
+    async def side_effect_update_post(post_id, message, props=None):
+        if "The answer is 42." in message:
+            final_response_posted.set()
+        return {"id": post_id}
+        
+    mock_api.update_post = AsyncMock(side_effect=side_effect_update_post)
 
-    # 3. Mock Goose ACP Client
-    mock_goose = MagicMock()
-    mock_goose.create_session = AsyncMock(return_value="session_abc")
-    mock_goose.process = MagicMock()
-    mock_goose.process.returncode = None
+    # 3. Setup Mock Goose Process
+    mock_process = MockProcess()
     
-    async def mock_prompt(sid, message):
-        assert sid == "session_abc"
-        assert "meaning of life" in message
-        yield {"type": "thinking", "text": "Analyzing the universe..."}
-        yield {"type": "content", "text": "The answer is 42."}
-        yield {"type": "final", "text": "The answer is 42."}
-    
-    mock_goose.prompt = mock_prompt
-    
-    # 4. Setup Bridge with Factory
+    async def side_effect_subprocess(*args, **kwargs):
+        return mock_process
+
+    # Helper to simulate Goose responses
+    async def simulate_goose_behavior():
+        try:
+            # 1. Handshake response (triggered by first create_session -> ensure_running)
+            await asyncio.sleep(0.05)
+            mock_process.feed_stdout({
+                "jsonrpc": "2.0", "id": 1, 
+                "result": {"capabilities": {"mcp": {"sse": True}}}
+            })
+            
+            # 2. session/new response (triggered by create_session)
+            await asyncio.sleep(0.05)
+            mock_process.feed_stdout({
+                "jsonrpc": "2.0", "id": 2, 
+                "result": {"sessionId": "session_abc"}
+            })
+            
+            # 3. session/prompt chunks (triggered by prompt)
+            await asyncio.sleep(0.05)
+            # Thinking chunk
+            mock_process.feed_stdout({
+                "jsonrpc": "2.0", "method": "session/update",
+                "params": {
+                    "sessionId": "session_abc",
+                    "update": {"sessionUpdate": "agent_thinking_chunk", "thinking": "Analyzing..."}
+                }
+            })
+            # Content chunk
+            mock_process.feed_stdout({
+                "jsonrpc": "2.0", "method": "session/update",
+                "params": {
+                    "sessionId": "session_abc",
+                    "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "The answer is 42."}}
+                }
+            })
+            # Final response (id 3 because prompt is the 3rd request: initialize, session/new, session/prompt)
+            mock_process.feed_stdout({
+                "jsonrpc": "2.0", "id": 3, 
+                "result": {"status": "completed"}
+            })
+        except Exception as e:
+            print(f"Simulator Error: {e}")
+
+    # 4. Setup Bridge with REAL GooseACPClient
     def goose_factory(user):
-        return mock_goose
+        return GooseACPClient(user, config=config)
 
     bridge = MattermostBridge(api=mock_api, config=config, goose_client_factory=goose_factory)
-    # Ensure our test post (create_at=1000) is processed
     bridge.last_since = 0
 
-    # 5. Execute Bridge Run with a controlled exit
-    # We need the loop to run at least once and then wait for tasks.
-    # The bridge.run() calls _update_channel_cache, then polls, THEN sleeps.
-    
-    loop_count = 0
-    # Capture the real sleep so we don't recurse
-    real_sleep = asyncio.sleep
-    
-    async def side_effect_sleep(interval):
-        nonlocal loop_count
-        loop_count += 1
-        # Wait for any background tasks to start and finish
-        # _process_post spawns a task, so we must yield control.
-        for _ in range(10):
-            if not bridge.background_tasks:
-                await real_sleep(0)
-                break
-            await asyncio.gather(*bridge.background_tasks)
-            
-        raise KeyboardInterrupt()
-
+    # 5. Execute Bridge Run in background
     with patch('mattermost_bridge.load_user_mapping', return_value={"user_1": "linux_alice"}), \
-         patch('asyncio.sleep', side_effect=side_effect_sleep):
-        await bridge.run()
+         patch('asyncio.create_subprocess_exec', side_effect=side_effect_subprocess):
+        
+        # Start the Goose simulator
+        simulator_task = asyncio.create_task(simulate_goose_behavior())
+        
+        # Start the bridge
+        bridge_task = asyncio.create_task(bridge.run())
+        
+        try:
+            # Wait for the flow to complete
+            await asyncio.wait_for(final_response_posted.wait(), timeout=5.0)
+            
+            # Wait for background tasks in bridge to finish (streaming might take a moment)
+            if bridge.background_tasks:
+                await asyncio.gather(*bridge.background_tasks)
+                
+        finally:
+            bridge_task.cancel()
+            simulator_task.cancel()
+            try:
+                await bridge_task
+            except asyncio.CancelledError:
+                pass
 
     # 6. Verifications
-    
-    # Verify initialization
     mock_api.get_me.assert_called_once()
     assert bridge.bot_id == "bot_id"
-    assert bridge.bot_mention == "@goose-bot"
-
-    # Verify polling happened
-    assert mock_api.get_channel_posts.called
     
-    # Verify session creation
-    mock_goose.create_session.assert_called_once()
+    # Check that GooseACPClient was actually used and created a session
     assert "user_1:post_123" in bridge.sessions
-    assert bridge.sessions["user_1:post_123"]["linux_user"] == "linux_alice"
+    assert bridge.sessions["user_1:post_123"]["id"] == "session_abc"
     
-    # Verify message processing
-    # Note: _handle_message is spawned as a task, so we might need a small wait if it's async
-    # However, since we used KeyboardInterrupt in the main loop AFTER calling _process_post,
-    # the task was created. We need to ensure it finished.
-    # In this test, because we didn't await the tasks in the loop (they are background tasks),
-    # we should wait for them.
-    
-    if bridge.background_tasks:
-        await asyncio.gather(*bridge.background_tasks)
-
     # Verify Mattermost feedback
-    # Expectation: 
-    # 1. Thinking post created
-    # 2. Post updated with content
-    # 3. Post updated with final result
-    
     assert mock_api.create_post.called
-    # First creation is thinking msg
-    first_post_call = mock_api.create_post.call_args_list[0]
-    assert ":thinking_face:" in first_post_call[0][1]
-    
-    # Final update
     assert mock_api.update_post.called
-    last_update_call = mock_api.update_post.call_args_list[-1]
-    assert "The answer is 42." in last_update_call[0][1]
-    # Check thinking trace in attachments
-    assert "attachments" in last_update_call[1]["props"]
-    assert "Analyzing the universe..." in last_update_call[1]["props"]["attachments"][0]["text"]
+    
+    # Verify final answer
+    found_content = False
+    for call in mock_api.update_post.call_args_list:
+        if "The answer is 42." in call[0][1]:
+            found_content = True
+            break
+    assert found_content, "Final answer not found in Mattermost updates"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,148 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
+from mattermost_bridge import MattermostBridge
+from config import Config
+
+@pytest.mark.asyncio
+async def test_bridge_integration_flow():
+    # 1. Setup Mock Config
+    config = Config(
+        mattermost_url="http://mattermost.example.com",
+        mattermost_token="fake-token",
+        approved_users=["alice"],
+        poll_interval=0.1,
+        debug=True,
+        goose_thinking_trace=True
+    )
+
+    # 2. Mock Mattermost API
+    mock_api = MagicMock()
+    # Mock initialization calls
+    mock_api.get_me = AsyncMock(return_value={"id": "bot_id", "username": "goose-bot"})
+    mock_api.get_direct_channels = AsyncMock(return_value=[])
+    mock_api.get_my_teams = AsyncMock(return_value=[{"id": "team_1"}])
+    mock_api.get_my_channels = AsyncMock(return_value=[{"id": "chan_1", "type": "O"}])
+    
+    # Mock user info
+    mock_api.get_user = AsyncMock(return_value={"id": "user_1", "username": "alice"})
+    
+    # Mock post fetching - first call returns a post, subsequent calls return nothing
+    test_post = {
+        "id": "post_123",
+        "user_id": "user_1",
+        "channel_id": "chan_1",
+        "message": "@goose-bot What is the meaning of life?",
+        "create_at": 1000
+    }
+    
+    # Track calls to simulate a single loop iteration
+    call_tracker = {"get_posts_count": 0}
+    
+    async def side_effect_get_posts(channel_id, since):
+        # The bridge polls all channels in the cache. 
+        # In this test, there's only 'chan_1'.
+        if call_tracker["get_posts_count"] == 0:
+            call_tracker["get_posts_count"] += 1
+            # Note: The bridge sorts posts by create_at and then calls _process_post
+            return {"posts": {"post_123": test_post}, "order": ["post_123"]}
+        return {"posts": {}, "order": []}
+
+    mock_api.get_channel_posts = AsyncMock(side_effect=side_effect_get_posts)
+    
+    # Mock post creation and updates
+    created_post = {"id": "bot_post_456"}
+    mock_api.create_post = AsyncMock(return_value=created_post)
+    mock_api.update_post = AsyncMock(return_value=created_post)
+
+    # 3. Mock Goose ACP Client
+    mock_goose = MagicMock()
+    mock_goose.create_session = AsyncMock(return_value="session_abc")
+    mock_goose.process = MagicMock()
+    mock_goose.process.returncode = None
+    
+    async def mock_prompt(sid, message):
+        assert sid == "session_abc"
+        assert "meaning of life" in message
+        yield {"type": "thinking", "text": "Analyzing the universe..."}
+        yield {"type": "content", "text": "The answer is 42."}
+        yield {"type": "final", "text": "The answer is 42."}
+    
+    mock_goose.prompt = mock_prompt
+    
+    # 4. Setup Bridge with Factory
+    def goose_factory(user):
+        return mock_goose
+
+    bridge = MattermostBridge(api=mock_api, config=config, goose_client_factory=goose_factory)
+    # Ensure our test post (create_at=1000) is processed
+    bridge.last_since = 0
+
+    # 5. Execute Bridge Run with a controlled exit
+    # We need the loop to run at least once and then wait for tasks.
+    # The bridge.run() calls _update_channel_cache, then polls, THEN sleeps.
+    
+    loop_count = 0
+    # Capture the real sleep so we don't recurse
+    real_sleep = asyncio.sleep
+    
+    async def side_effect_sleep(interval):
+        nonlocal loop_count
+        loop_count += 1
+        # Wait for any background tasks to start and finish
+        # _process_post spawns a task, so we must yield control.
+        for _ in range(10):
+            if not bridge.background_tasks:
+                await real_sleep(0)
+                break
+            await asyncio.gather(*bridge.background_tasks)
+            
+        raise KeyboardInterrupt()
+
+    with patch('mattermost_bridge.load_user_mapping', return_value={"user_1": "linux_alice"}), \
+         patch('asyncio.sleep', side_effect=side_effect_sleep):
+        await bridge.run()
+
+    # 6. Verifications
+    
+    # Verify initialization
+    mock_api.get_me.assert_called_once()
+    assert bridge.bot_id == "bot_id"
+    assert bridge.bot_mention == "@goose-bot"
+
+    # Verify polling happened
+    assert mock_api.get_channel_posts.called
+    
+    # Verify session creation
+    mock_goose.create_session.assert_called_once()
+    assert "user_1:post_123" in bridge.sessions
+    assert bridge.sessions["user_1:post_123"]["linux_user"] == "linux_alice"
+    
+    # Verify message processing
+    # Note: _handle_message is spawned as a task, so we might need a small wait if it's async
+    # However, since we used KeyboardInterrupt in the main loop AFTER calling _process_post,
+    # the task was created. We need to ensure it finished.
+    # In this test, because we didn't await the tasks in the loop (they are background tasks),
+    # we should wait for them.
+    
+    if bridge.background_tasks:
+        await asyncio.gather(*bridge.background_tasks)
+
+    # Verify Mattermost feedback
+    # Expectation: 
+    # 1. Thinking post created
+    # 2. Post updated with content
+    # 3. Post updated with final result
+    
+    assert mock_api.create_post.called
+    # First creation is thinking msg
+    first_post_call = mock_api.create_post.call_args_list[0]
+    assert ":thinking_face:" in first_post_call[0][1]
+    
+    # Final update
+    assert mock_api.update_post.called
+    last_update_call = mock_api.update_post.call_args_list[-1]
+    assert "The answer is 42." in last_update_call[0][1]
+    # Check thinking trace in attachments
+    assert "attachments" in last_update_call[1]["props"]
+    assert "Analyzing the universe..." in last_update_call[1]["props"]["attachments"][0]["text"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,24 +1,10 @@
 import pytest
 import asyncio
-import json
 from unittest.mock import MagicMock, AsyncMock, patch
 from mattermost_bridge import MattermostBridge
 from goose_acp_client import GooseACPClient
 from config import Config
-
-class MockProcess:
-    def __init__(self):
-        self.stdin = MagicMock()
-        self.stdin.write = MagicMock()
-        self.stdin.drain = AsyncMock(return_value=None)
-        self.stdout = asyncio.StreamReader()
-        self.stderr = asyncio.StreamReader()
-        self.returncode = None
-        self.terminate = MagicMock()
-
-    def feed_stdout(self, data: dict):
-        line = json.dumps(data) + "\n"
-        self.stdout.feed_data(line.encode())
+from goose_simulator import MockProcess, simulate_goose_behavior
 
 @pytest.mark.asyncio
 async def test_bridge_integration_flow_with_goose_process():
@@ -74,49 +60,6 @@ async def test_bridge_integration_flow_with_goose_process():
     async def side_effect_subprocess(*args, **kwargs):
         return mock_process
 
-    # Helper to simulate Goose responses
-    async def simulate_goose_behavior():
-        try:
-            # 1. Handshake response (triggered by first create_session -> ensure_running)
-            await asyncio.sleep(0.05)
-            mock_process.feed_stdout({
-                "jsonrpc": "2.0", "id": 1, 
-                "result": {"capabilities": {"mcp": {"sse": True}}}
-            })
-            
-            # 2. session/new response (triggered by create_session)
-            await asyncio.sleep(0.05)
-            mock_process.feed_stdout({
-                "jsonrpc": "2.0", "id": 2, 
-                "result": {"sessionId": "session_abc"}
-            })
-            
-            # 3. session/prompt chunks (triggered by prompt)
-            await asyncio.sleep(0.05)
-            # Thinking chunk
-            mock_process.feed_stdout({
-                "jsonrpc": "2.0", "method": "session/update",
-                "params": {
-                    "sessionId": "session_abc",
-                    "update": {"sessionUpdate": "agent_thinking_chunk", "thinking": "Analyzing..."}
-                }
-            })
-            # Content chunk
-            mock_process.feed_stdout({
-                "jsonrpc": "2.0", "method": "session/update",
-                "params": {
-                    "sessionId": "session_abc",
-                    "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "The answer is 42."}}
-                }
-            })
-            # Final response (id 3 because prompt is the 3rd request: initialize, session/new, session/prompt)
-            mock_process.feed_stdout({
-                "jsonrpc": "2.0", "id": 3, 
-                "result": {"status": "completed"}
-            })
-        except Exception as e:
-            print(f"Simulator Error: {e}")
-
     # 4. Setup Bridge with REAL GooseACPClient
     def goose_factory(user):
         return GooseACPClient(user, config=config)
@@ -128,8 +71,8 @@ async def test_bridge_integration_flow_with_goose_process():
     with patch('mattermost_bridge.load_user_mapping', return_value={"user_1": "linux_alice"}), \
          patch('asyncio.create_subprocess_exec', side_effect=side_effect_subprocess):
         
-        # Start the Goose simulator
-        simulator_task = asyncio.create_task(simulate_goose_behavior())
+        # Start the Goose simulator from the util file
+        simulator_task = asyncio.create_task(simulate_goose_behavior(mock_process))
         
         # Start the bridge
         bridge_task = asyncio.create_task(bridge.run())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,6 +101,15 @@ async def test_bridge_integration_flow_with_goose_process():
     assert "user_1:post_123" in bridge.sessions
     assert bridge.sessions["user_1:post_123"]["id"] == "session_abc"
     
+    # Verify system prompt was passed to Goose
+    found_system_prompt = False
+    for call in mock_process.stdin.write.call_args_list:
+        sent_data = call[0][0].decode()
+        if "systemPrompt" in sent_data and "primary user is @alice" in sent_data:
+            found_system_prompt = True
+            break
+    assert found_system_prompt, "System prompt not found in data sent to Goose"
+
     # Verify Mattermost feedback
     assert mock_api.create_post.called
     assert mock_api.update_post.called

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,15 +101,6 @@ async def test_bridge_integration_flow_with_goose_process():
     assert "user_1:post_123" in bridge.sessions
     assert bridge.sessions["user_1:post_123"]["id"] == "session_abc"
     
-    # Verify system prompt was passed to Goose
-    found_system_prompt = False
-    for call in mock_process.stdin.write.call_args_list:
-        sent_data = call[0][0].decode()
-        if "systemPrompt" in sent_data and "primary user is @alice" in sent_data:
-            found_system_prompt = True
-            break
-    assert found_system_prompt, "System prompt not found in data sent to Goose"
-
     # Verify Mattermost feedback
     assert mock_api.create_post.called
     assert mock_api.update_post.called

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,10 +18,15 @@ def mcp_server(mock_bridge):
 @pytest.mark.asyncio
 async def test_list_tools(mcp_server):
     tools = await mcp_server.list_tools()
-    assert len(tools) == 2
+    assert len(tools) == 7
     tool_names = [t["name"] for t in tools]
     assert "send_message" in tool_names
     assert "get_channels" in tool_names
+    assert "get_thread_context" in tool_names
+    assert "search_messages" in tool_names
+    assert "search_users" in tool_names
+    assert "get_user_info" in tool_names
+    assert "send_direct_message" in tool_names
 
 @pytest.mark.asyncio
 async def test_call_tool_send_message(mcp_server, mock_bridge):
@@ -44,6 +49,56 @@ async def test_call_tool_get_channels(mcp_server, mock_bridge):
     assert len(result) == 1
     assert "town-square" in result[0]["text"]
     mock_bridge._update_channel_cache.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_call_tool_get_thread_context(mcp_server, mock_bridge):
+    mock_bridge.api.get_thread = AsyncMock(return_value={
+        "posts": {
+            "p1": {"message": "first", "create_at": 100, "user_id": "u1"},
+            "p2": {"message": "second", "create_at": 200, "user_id": "u2"}
+        }
+    })
+    mock_bridge.api.get_user = AsyncMock(side_effect=lambda uid: {"username": f"user_{uid}"})
+    
+    result = await mcp_server.call_tool("get_thread_context", {"root_id": "r1"})
+    
+    assert len(result) == 1
+    assert "[Sender: @user_u1] first" in result[0]["text"]
+    assert "[Sender: @user_u2] second" in result[0]["text"]
+    mock_bridge.api.get_thread.assert_called_once_with("r1")
+
+@pytest.mark.asyncio
+async def test_call_tool_search_messages(mcp_server, mock_bridge):
+    mock_bridge.api.get_my_teams = AsyncMock(return_value=[{"id": "t1"}])
+    mock_bridge.api.search_posts = AsyncMock(return_value={
+        "posts": {"p1": {"id": "p1", "channel_id": "c1", "message": "found it", "create_at": 100}}
+    })
+    
+    result = await mcp_server.call_tool("search_messages", {"terms": "query"})
+    
+    assert len(result) == 1
+    assert "found it" in result[0]["text"]
+    mock_bridge.api.search_posts.assert_called_once_with("t1", "query")
+
+@pytest.mark.asyncio
+async def test_call_tool_send_direct_message(mcp_server, mock_bridge):
+    mock_bridge.api.get_me = AsyncMock(return_value={"id": "me_id"})
+    mock_bridge.api.search_users = AsyncMock(side_effect=[
+        [{"id": "u1_id", "username": "user1"}]
+    ])
+    mock_bridge.api.create_direct_channel = AsyncMock(return_value={"id": "dm_channel"})
+    
+    result = await mcp_server.call_tool("send_direct_message", {
+        "usernames": ["@user1"],
+        "message": "private hello"
+    })
+    
+    assert "Direct message sent" in result[0]["text"]
+    mock_bridge.api.create_direct_channel.assert_called_once()
+    # Should include both user1 and me
+    user_ids = mock_bridge.api.create_direct_channel.call_args[0][0]
+    assert "u1_id" in user_ids
+    assert "me_id" in user_ids
 
 @pytest.mark.asyncio
 async def test_call_tool_unknown(mcp_server):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,9 +17,9 @@ def mcp_server(mock_bridge):
 
 @pytest.mark.asyncio
 async def test_list_tools(mcp_server):
-    tools = await mcp_server.list_tools()
+    tools = await mcp_server.mcp.list_tools()
     assert len(tools) == 7
-    tool_names = [t["name"] for t in tools]
+    tool_names = [t.name for t in tools]
     assert "send_message" in tool_names
     assert "get_channels" in tool_names
     assert "get_thread_context" in tool_names
@@ -36,18 +36,18 @@ async def test_call_tool_send_message(mcp_server, mock_bridge):
         "root_id": "r1"
     }
     
-    result = await mcp_server.call_tool("send_message", arguments)
+    result, _ = await mcp_server.mcp.call_tool("send_message", arguments)
     
     assert len(result) == 1
-    assert result[0]["text"] == "Message sent successfully"
+    assert result[0].text == "Message sent successfully"
     mock_bridge.api.create_post.assert_called_once_with("c1", "hello", root_id="r1")
 
 @pytest.mark.asyncio
 async def test_call_tool_get_channels(mcp_server, mock_bridge):
-    result = await mcp_server.call_tool("get_channels", {})
+    result, _ = await mcp_server.mcp.call_tool("get_channels", {})
     
     assert len(result) == 1
-    assert "town-square" in result[0]["text"]
+    assert "town-square" in result[0].text
     mock_bridge._update_channel_cache.assert_called_once()
 
 @pytest.mark.asyncio
@@ -60,11 +60,11 @@ async def test_call_tool_get_thread_context(mcp_server, mock_bridge):
     })
     mock_bridge.api.get_user = AsyncMock(side_effect=lambda uid: {"username": f"user_{uid}"})
     
-    result = await mcp_server.call_tool("get_thread_context", {"root_id": "r1"})
+    result, _ = await mcp_server.mcp.call_tool("get_thread_context", {"root_id": "r1"})
     
     assert len(result) == 1
-    assert "[Sender: @user_u1] first" in result[0]["text"]
-    assert "[Sender: @user_u2] second" in result[0]["text"]
+    assert "[Sender: @user_u1] first" in result[0].text
+    assert "[Sender: @user_u2] second" in result[0].text
     mock_bridge.api.get_thread.assert_called_once_with("r1")
 
 @pytest.mark.asyncio
@@ -74,10 +74,10 @@ async def test_call_tool_search_messages(mcp_server, mock_bridge):
         "posts": {"p1": {"id": "p1", "channel_id": "c1", "message": "found it", "create_at": 100}}
     })
     
-    result = await mcp_server.call_tool("search_messages", {"terms": "query"})
+    result, _ = await mcp_server.mcp.call_tool("search_messages", {"terms": "query"})
     
     assert len(result) == 1
-    assert "found it" in result[0]["text"]
+    assert "found it" in result[0].text
     mock_bridge.api.search_posts.assert_called_once_with("t1", "query")
 
 @pytest.mark.asyncio
@@ -88,12 +88,12 @@ async def test_call_tool_send_direct_message(mcp_server, mock_bridge):
     ])
     mock_bridge.api.create_direct_channel = AsyncMock(return_value={"id": "dm_channel"})
     
-    result = await mcp_server.call_tool("send_direct_message", {
+    result, _ = await mcp_server.mcp.call_tool("send_direct_message", {
         "usernames": ["@user1"],
         "message": "private hello"
     })
     
-    assert "Direct message sent" in result[0]["text"]
+    assert "Direct message sent" in result[0].text
     mock_bridge.api.create_direct_channel.assert_called_once()
     # Should include both user1 and me
     user_ids = mock_bridge.api.create_direct_channel.call_args[0][0]
@@ -102,5 +102,6 @@ async def test_call_tool_send_direct_message(mcp_server, mock_bridge):
 
 @pytest.mark.asyncio
 async def test_call_tool_unknown(mcp_server):
-    with pytest.raises(ValueError, match="Unknown tool: ghost_tool"):
-        await mcp_server.call_tool("ghost_tool", {})
+    from mcp.server.fastmcp.exceptions import ToolError
+    with pytest.raises(ToolError, match="Unknown tool: ghost_tool"):
+        await mcp_server.mcp.call_tool("ghost_tool", {})

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from mcp_server import MattermostMCPServer
+
+@pytest.fixture
+def mock_bridge():
+    bridge = MagicMock()
+    bridge.api = MagicMock()
+    bridge.api.create_post = AsyncMock(return_value={"id": "post_123"})
+    bridge._update_channel_cache = AsyncMock()
+    bridge.channels_cache = [{"id": "chan_1", "name": "town-square"}]
+    return bridge
+
+@pytest.fixture
+def mcp_server(mock_bridge):
+    return MattermostMCPServer(mock_bridge)
+
+@pytest.mark.asyncio
+async def test_list_tools(mcp_server):
+    tools = await mcp_server.list_tools()
+    assert len(tools) == 2
+    tool_names = [t["name"] for t in tools]
+    assert "send_message" in tool_names
+    assert "get_channels" in tool_names
+
+@pytest.mark.asyncio
+async def test_call_tool_send_message(mcp_server, mock_bridge):
+    arguments = {
+        "channel_id": "c1",
+        "message": "hello",
+        "root_id": "r1"
+    }
+    
+    result = await mcp_server.call_tool("send_message", arguments)
+    
+    assert len(result) == 1
+    assert result[0]["text"] == "Message sent successfully"
+    mock_bridge.api.create_post.assert_called_once_with("c1", "hello", root_id="r1")
+
+@pytest.mark.asyncio
+async def test_call_tool_get_channels(mcp_server, mock_bridge):
+    result = await mcp_server.call_tool("get_channels", {})
+    
+    assert len(result) == 1
+    assert "town-square" in result[0]["text"]
+    mock_bridge._update_channel_cache.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_call_tool_unknown(mcp_server):
+    with pytest.raises(ValueError, match="Unknown tool: ghost_tool"):
+        await mcp_server.call_tool("ghost_tool", {})


### PR DESCRIPTION
Integrated an MCP server directly into the bridge process as requested in issue #29. The server runs on a separate thread and is passed to Goose as a remote MCP server. It also accounts for Goose's SSE support capability.