### PR TITLE
feat: provide thread ID context to agent

### DIFF
--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -198,7 +198,7 @@ class MattermostBridge:
                         "linux_user": linux_user,
                     }
                     # Inform the agent about the current context
-                    context_msg = f"SYSTEM: You are currently processing a Mattermost thread. Channel ID: {channel_id}, Root Post ID (Thread ID): {root_id}. You can use these IDs with your tools to fetch more context if needed."
+                    context_msg = f"SYSTEM: You are participating in a Mattermost thread. You automatically receive messages directed at you from your primary user. Channel ID: {channel_id}, Root Post ID (Thread ID): {root_id}. You can use these IDs with your tools to fetch more context if needed."
                     async for _ in goose.prompt(sid, context_msg):
                         pass
 

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -188,6 +188,7 @@ class MattermostBridge:
         async with self.session_locks[session_key]:
             try:
                 message = clean_message(message, self.bot_mention)
+                print(f"[{datetime.now()}] User {sender_id} says: {message[:100]}...")
 
                 if session_key not in self.sessions:
                     print(f"[{datetime.now()}] Creating new Goose session for {session_key}")
@@ -204,7 +205,6 @@ class MattermostBridge:
 
                 session_data = self.sessions[session_key]
                 goose_sid = session_data["id"]
-                print(f"[{datetime.now()}] User {sender_id} says: {message[:100]}...")
 
                 try:
                     await self._stream_response_to_mattermost(goose, goose_sid, message, channel_id, root_id)

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -192,10 +192,15 @@ class MattermostBridge:
                 if session_key not in self.sessions:
                     print(f"[{datetime.now()}] Creating new Goose session for {session_key}")
                     
+                    sid = await goose.create_session()
                     self.sessions[session_key] = {
-                        "id": await goose.create_session(),
+                        "id": sid,
                         "linux_user": linux_user,
                     }
+                    # Inform the agent about the current context
+                    context_msg = f"SYSTEM: You are currently processing a Mattermost thread. Channel ID: {channel_id}, Root Post ID (Thread ID): {root_id}. You can use these IDs with your tools to fetch more context if needed."
+                    async for _ in goose.prompt(sid, context_msg):
+                        pass
 
                 session_data = self.sessions[session_key]
                 goose_sid = session_data["id"]

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -198,7 +198,7 @@ class MattermostBridge:
                         "linux_user": linux_user,
                     }
                     # Inform the agent about the current context
-                    context_msg = f"SYSTEM: You are participating in a Mattermost thread. You automatically receive messages directed at you from your primary user. Channel ID: {channel_id}, Root Post ID (Thread ID): {root_id}. You can use these IDs with your tools to fetch more context if needed."
+                    context_msg = f"SYSTEM: Mattermost Channel ID: {channel_id}, Root Post ID (Thread ID): {root_id}. You can use these IDs with your tools to fetch more context about the current channel/thread if needed."
                     async for _ in goose.prompt(sid, context_msg):
                         pass
 

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -223,7 +223,8 @@ class MattermostBridge:
                     }
                     goose_sid = self.sessions[session_key]["id"]
                     # Also prepend context for the fresh retry session
-                    await self._stream_response_to_mattermost(goose, goose_sid, f"{context_msg}\n\n{message}", channel_id, root_id)
+                    retry_context = f"{context_msg} NOTE: The previous session for this thread terminated unexpectedly. Context from earlier in this conversation has been lost, but you can use the IDs above to try to recover history if needed."
+                    await self._stream_response_to_mattermost(goose, goose_sid, f"{retry_context}\n\n{message}", channel_id, root_id)
 
             except Exception as e:
                 print(f"[{datetime.now()}] Error handling message for {session_key}: {e}")

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -175,6 +175,7 @@ class MattermostBridge:
         channel_id = post["channel_id"]
         root_id = post.get("root_id") or post["id"]
         session_key = get_session_key(sender_id, root_id)
+        context_msg = f"SYSTEM: Mattermost Channel ID: {channel_id}, Root Post ID (Thread ID): {root_id}. You can use these IDs with your tools to fetch more context about the current channel/thread if needed."
 
         self.active_tasks[session_key] = asyncio.current_task()
 
@@ -190,6 +191,7 @@ class MattermostBridge:
                 message = clean_message(message, self.bot_mention)
                 print(f"[{datetime.now()}] User {sender_id} says: {message[:100]}...")
 
+                is_new_session = False
                 if session_key not in self.sessions:
                     print(f"[{datetime.now()}] Creating new Goose session for {session_key}")
                     
@@ -198,16 +200,16 @@ class MattermostBridge:
                         "id": sid,
                         "linux_user": linux_user,
                     }
-                    # Inform the agent about the current context
-                    context_msg = f"SYSTEM: Mattermost Channel ID: {channel_id}, Root Post ID (Thread ID): {root_id}. You can use these IDs with your tools to fetch more context about the current channel/thread if needed."
-                    async for _ in goose.prompt(sid, context_msg):
-                        pass
+                    is_new_session = True
 
                 session_data = self.sessions[session_key]
                 goose_sid = session_data["id"]
 
+                # Prepend context for the first message in a session to avoid an extra turn
+                prompt_text = f"{context_msg}\n\n{message}" if is_new_session else message
+
                 try:
-                    await self._stream_response_to_mattermost(goose, goose_sid, message, channel_id, root_id)
+                    await self._stream_response_to_mattermost(goose, goose_sid, prompt_text, channel_id, root_id)
                 except (ValueError, RuntimeError, asyncio.TimeoutError) as e:
                     print(f"[{datetime.now()}] Session {session_key} lost, retrying once: {e}")
                     await self.api.create_post(
@@ -220,7 +222,8 @@ class MattermostBridge:
                         "linux_user": linux_user,
                     }
                     goose_sid = self.sessions[session_key]["id"]
-                    await self._stream_response_to_mattermost(goose, goose_sid, message, channel_id, root_id)
+                    # Also prepend context for the fresh retry session
+                    await self._stream_response_to_mattermost(goose, goose_sid, f"{context_msg}\n\n{message}", channel_id, root_id)
 
             except Exception as e:
                 print(f"[{datetime.now()}] Error handling message for {session_key}: {e}")

--- a/tests/goose_simulator.py
+++ b/tests/goose_simulator.py
@@ -35,8 +35,15 @@ async def simulate_goose_behavior(mock_process: MockProcess, session_id: str = "
             "jsonrpc": "2.0", "id": 2, 
             "result": {"sessionId": session_id}
         })
+
+        # 3. Handle the system context prompt (id: 3)
+        await asyncio.sleep(0.05)
+        mock_process.feed_stdout({
+            "jsonrpc": "2.0", "id": 3, 
+            "result": {"status": "completed"}
+        })
         
-        # 3. session/prompt chunks
+        # 4. session/prompt chunks for the actual user message (id: 4)
         await asyncio.sleep(0.05)
         # Thinking chunk
         mock_process.feed_stdout({
@@ -56,7 +63,7 @@ async def simulate_goose_behavior(mock_process: MockProcess, session_id: str = "
         })
         # Final response
         mock_process.feed_stdout({
-            "jsonrpc": "2.0", "id": 3, 
+            "jsonrpc": "2.0", "id": 4, 
             "result": {"status": "completed"}
         })
     except Exception as e:

--- a/tests/goose_simulator.py
+++ b/tests/goose_simulator.py
@@ -36,15 +36,9 @@ async def simulate_goose_behavior(mock_process: MockProcess, session_id: str = "
             "result": {"sessionId": session_id}
         })
 
-        # 3. Handle the system context prompt (id: 3)
+        # 3. Handle the prompt (which now includes both context and user message)
         await asyncio.sleep(0.05)
-        mock_process.feed_stdout({
-            "jsonrpc": "2.0", "id": 3, 
-            "result": {"status": "completed"}
-        })
         
-        # 4. session/prompt chunks for the actual user message (id: 4)
-        await asyncio.sleep(0.05)
         # Thinking chunk
         mock_process.feed_stdout({
             "jsonrpc": "2.0", "method": "session/update",
@@ -61,9 +55,10 @@ async def simulate_goose_behavior(mock_process: MockProcess, session_id: str = "
                 "update": {"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": final_text}}
             }
         })
-        # Final response
+        
+        # Final response for the prompt (id: 3)
         mock_process.feed_stdout({
-            "jsonrpc": "2.0", "id": 4, 
+            "jsonrpc": "2.0", "id": 3, 
             "result": {"status": "completed"}
         })
     except Exception as e:

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -22,12 +22,15 @@ def mock_goose_client():
     client.create_session = AsyncMock(return_value="session_1")
     client.send_request = AsyncMock(return_value={})
     
-    async def mock_prompt(sid, msg):
+    # We'll use a mock that tracks calls
+    client.prompt = MagicMock()
+    
+    async def mock_prompt_gen(sid, msg):
         yield {"type": "thinking", "text": "let me see"}
         yield {"type": "content", "text": "the answer is 42"}
         yield {"type": "final", "text": "the answer is 42"}
     
-    client.prompt = mock_prompt
+    client.prompt.side_effect = mock_prompt_gen
     return client
 
 @pytest.mark.asyncio
@@ -56,14 +59,58 @@ async def test_handle_message(config, mock_api, mock_goose_client):
     with patch('mattermost_bridge.load_user_mapping', return_value={"user_id_1": "linux_user"}):
         await bridge._handle_message(post, "linux_user")
         
-        # Verify goose was prompted
-        # The prompt is an async generator, so we check if it was called
-        # mock_goose_client.prompt is replaced by our mock_prompt function in the fixture
+        # Verify goose was prompted with combined context
+        assert mock_goose_client.prompt.called
+        args, kwargs = mock_goose_client.prompt.call_args
+        prompt_text = args[1]
+        assert "SYSTEM: Mattermost Channel ID: channel_1" in prompt_text
+        assert "Root Post ID (Thread ID): post_1" in prompt_text
+        assert "hello" in prompt_text
         
         # Verify Mattermost posts were created/updated
         assert mock_api.create_post.called
         # First post is "Thinking..."
         assert mock_api.create_post.call_args_list[0][0][1] == ":thinking_face: **Thinking...**"
+
+@pytest.mark.asyncio
+async def test_handle_message_retry(config, mock_api, mock_goose_client):
+    factory = lambda user: mock_goose_client
+    bridge = MattermostBridge(api=mock_api, config=config, goose_client_factory=factory)
+    bridge.bot_mention = "@bot"
+    
+    post = {
+        "id": "post_1",
+        "user_id": "user_id_1",
+        "channel_id": "channel_1",
+        "message": "@bot hello"
+    }
+
+    # Simulate a failure on first prompt, then success on second
+    call_count = 0
+    async def mock_prompt_with_fail(sid, msg):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("Goose connection lost")
+        yield {"type": "final", "text": "retry success"}
+        
+    mock_goose_client.prompt.side_effect = mock_prompt_with_fail
+    
+    with patch('mattermost_bridge.load_user_mapping', return_value={"user_id_1": "linux_user"}):
+        await bridge._handle_message(post, "linux_user")
+        
+        # Should have called prompt twice
+        assert mock_goose_client.prompt.call_count == 2
+        
+        # Second call should have the retry context
+        args, kwargs = mock_goose_client.prompt.call_args
+        prompt_text = args[1]
+        assert "NOTE: The previous session for this thread terminated unexpectedly" in prompt_text
+        assert "hello" in prompt_text
+        
+        # Verify we informed the user about the reset
+        reset_post_call = [c for c in mock_api.create_post.call_args_list if "Notice: Connection to Goose was reset" in str(c)]
+        assert len(reset_post_call) > 0
 
 @pytest.mark.asyncio
 async def test_session_pruning(config, mock_api, mock_goose_client):

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -20,6 +20,7 @@ def mock_api():
 def mock_goose_client():
     client = MagicMock()
     client.create_session = AsyncMock(return_value="session_1")
+    client.send_request = AsyncMock(return_value={})
     
     async def mock_prompt(sid, msg):
         yield {"type": "thinking", "text": "let me see"}


### PR DESCRIPTION
This PR adds an initial system prompt to new Goose sessions informing the agent of the current Mattermost Channel ID and Root Post ID (Thread ID). This allows the agent to use tools like  effectively.