### PR TITLE
feat: implement delta-based context injection (Approach 1)

### DIFF
--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -208,6 +208,7 @@ class MattermostBridge:
                     self.sessions[session_key] = {
                         "id": sid,
                         "linux_user": linux_user,
+                        "last_seen_at": 0,
                     }
                     is_new_session = True
 
@@ -216,6 +217,41 @@ class MattermostBridge:
 
                 # Prepend context for the first message in a session to avoid an extra turn
                 prompt_text = f"{context_msg}\n\n{message}" if is_new_session else message
+
+                # Delta-based Context Injection
+                if not is_new_session:
+                    last_seen = session_data.get("last_seen_at", 0)
+                    thread_data = await self.api.get_thread(root_id)
+                    if thread_data and "posts" in thread_data:
+                        posts = thread_data["posts"]
+                        current_post_id = post["id"]
+                        new_messages = []
+                        
+                        # Sort posts by create_at
+                        sorted_thread_posts = sorted(posts.values(), key=lambda x: x["create_at"])
+                        
+                        user_cache = {}
+                        for p in sorted_thread_posts:
+                            if p["create_at"] > last_seen and p["id"] != current_post_id:
+                                uid = p["user_id"]
+                                if uid not in user_cache:
+                                    u_info = await self.api.get_user(uid)
+                                    user_cache[uid] = u_info.get("username", "unknown") if u_info else "unknown"
+                                
+                                username = user_cache[uid]
+                                msg_text = clean_message(p["message"], self.bot_mention)
+                                if msg_text:
+                                    new_messages.append(f"{username}: {msg_text}")
+                        
+                        if new_messages:
+                            context_update = f"SYSTEM: While you were away, the following messages were posted: [{', '.join(new_messages)}]"
+                            if self.config.debug:
+                                print(f"[{datetime.now()}] Injecting delta context for {session_key}")
+                            async for _ in goose.prompt(goose_sid, context_update):
+                                pass
+                
+                # Update last_seen_at to the current message's timestamp
+                session_data["last_seen_at"] = post["create_at"]
 
                 try:
                     await self._stream_response_to_mattermost(goose, goose_sid, prompt_text, channel_id, root_id)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,6 +25,7 @@ async def test_bridge_integration_flow_with_goose_process():
     mock_api.get_my_teams = AsyncMock(return_value=[{"id": "team_1"}])
     mock_api.get_my_channels = AsyncMock(return_value=[{"id": "chan_1", "type": "O"}])
     mock_api.get_user = AsyncMock(return_value={"id": "user_1", "username": "alice"})
+    mock_api.get_thread = AsyncMock(return_value={"posts": {}})
     
     test_post = {
         "id": "post_123",

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -85,7 +85,8 @@ async def test_handle_message_retry(config, mock_api, mock_goose_client):
         "id": "post_1",
         "user_id": "user_id_1",
         "channel_id": "channel_1",
-        "message": "@bot hello"
+        "message": "@bot hello",
+        "create_at": 1000
     }
 
     # Simulate a failure on first prompt, then success on second

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -15,6 +15,7 @@ def mock_api():
     api.create_post = AsyncMock(return_value={"id": "post_id"})
     api.update_post = AsyncMock()
     api.get_user = AsyncMock(return_value={"username": "user1"})
+    api.get_thread = AsyncMock(return_value={"posts": {}})
     return api
 
 @pytest.fixture
@@ -53,7 +54,8 @@ async def test_handle_message(config, mock_api, mock_goose_client):
         "id": "post_1",
         "user_id": "user_id_1",
         "channel_id": "channel_1",
-        "message": "@bot hello"
+        "message": "@bot hello",
+        "create_at": 1000
     }
     
     # We mock load_user_mapping to avoid file IO
@@ -173,7 +175,7 @@ async def test_require_user_mapping(config, mock_api):
     bridge.bot_mention = "@bot"
     
     post = {
-        "id": "p1", "user_id": "u1", "channel_id": "c1", "message": "@bot hello"
+        "id": "p1", "user_id": "u1", "channel_id": "c1", "message": "@bot hello", "create_at": 1000
     }
     
     with patch('mattermost_bridge.load_user_mapping', return_value={}):
@@ -193,7 +195,7 @@ async def test_concurrency_locking(config, mock_api, mock_goose_client):
         yield {"type": "final", "text": "done"}
     mock_goose_client.prompt = slow_prompt
     
-    post = {"id": "p1", "user_id": "u1", "channel_id": "c1", "message": "@bot hello"}
+    post = {"id": "p1", "user_id": "u1", "channel_id": "c1", "message": "@bot hello", "create_at": 1000}
     
     with patch('mattermost_bridge.load_user_mapping', return_value={"u1": "linux1"}):
         # Start two tasks for the same thread


### PR DESCRIPTION
This PR implements Approach 1 from issue #33, which provides the agent with missed thread context by identifying messages posted since the session's last activity and injecting them as a system prompt.

Closes #33