### PR TITLE
feat: support simplified live thinking trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The bridge is configured via environment variables in the `.env` file:
 | `POLL_INTERVAL` | How often (in seconds) the bridge checks for new messages. | `1` |
 | `DEBUG` | Set to `true` to see detailed JSON-RPC logs for troubleshooting. | `false` |
 | `GOOSE_THINKING_TRACE` | When enabled, the agent's internal "thinking" steps are shown as message attachments. | `true` |
+| `GOOSE_THINKING_TRACE_SIMPLIFIED` | When enabled, shows a compact "Thinking... [Last action]" status instead of full attachments. | `true` |
 | `RPC_TIMEOUT` | Seconds to wait for Goose to respond before timing out. | `600` |
 | `REQUIRE_USER_MAPPING` | If `true`, only users explicitly listed in the mapping file can use the bot. | `false` |
 | `MAX_SESSIONS` | The maximum number of active thread contexts to keep before recycling. | `100` |

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,7 @@ class Config:
     poll_interval: int = int(os.getenv("POLL_INTERVAL", "1"))
     debug: bool = os.getenv("DEBUG", "false").lower() == "true"
     goose_thinking_trace: bool = os.getenv("GOOSE_THINKING_TRACE", "true").lower() == "true"
+    goose_thinking_trace_simplified: bool = os.getenv("GOOSE_THINKING_TRACE_SIMPLIFIED", "false").lower() == "true"
     rpc_timeout: int = int(os.getenv("RPC_TIMEOUT", "600"))
     max_sessions: int = int(os.getenv("MAX_SESSIONS", "100"))
     user_mapping_file: str = os.getenv("USER_MAPPING_FILE", "user_mapping.json")

--- a/src/config.py
+++ b/src/config.py
@@ -15,7 +15,7 @@ class Config:
     poll_interval: int = int(os.getenv("POLL_INTERVAL", "1"))
     debug: bool = os.getenv("DEBUG", "false").lower() == "true"
     goose_thinking_trace: bool = os.getenv("GOOSE_THINKING_TRACE", "true").lower() == "true"
-    goose_thinking_trace_simplified: bool = os.getenv("GOOSE_THINKING_TRACE_SIMPLIFIED", "false").lower() == "true"
+    goose_thinking_trace_simplified: bool = os.getenv("GOOSE_THINKING_TRACE_SIMPLIFIED", "true").lower() == "true"
     rpc_timeout: int = int(os.getenv("RPC_TIMEOUT", "600"))
     max_sessions: int = int(os.getenv("MAX_SESSIONS", "100"))
     user_mapping_file: str = os.getenv("USER_MAPPING_FILE", "user_mapping.json")

--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -325,7 +325,7 @@ class GooseACPClient:
         elif session_update == "tool_call_update":
             title = update.get("title")
             if title:
-                return {"type": "thinking", "text": f"\n**Updated**: `{title}`\n"}
+                return {"type": "thinking", "text": title}
         
         if self.config.debug:
             print(f"DEBUG: Unknown or unhandled chunk format: {chunk}")

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -129,7 +129,7 @@ class MattermostBridge:
 
         async for update in goose.prompt(sid, msg):
             if update["type"] == "thinking":
-                thinking_trace += f"\n\n**Working**: {update["text"]}"
+                thinking_trace += f"\n\n**Working**: {update['text']}"
                 last_thinking_text = update["text"].strip()
             elif update["type"] == "tool":
                 thinking_trace += f"\n\n**Using tool**: `{update['name']}`\n"

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -129,7 +129,7 @@ class MattermostBridge:
 
         async for update in goose.prompt(sid, msg):
             if update["type"] == "thinking":
-                thinking_trace += update["text"]
+                thinking_trace += f"\n\n**Working**: {update["text"]}"
                 last_thinking_text = update["text"].strip()
             elif update["type"] == "tool":
                 thinking_trace += f"\n\n**Using tool**: `{update['name']}`\n"

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -157,7 +157,7 @@ class MattermostBridge:
                     # While thinking/streaming
                     if self.config.goose_thinking_trace_simplified and last_thinking_text:
                          # Simplified mode: Thinking... [Last action]
-                         resp_msg = f"{full_response or THINKING_MSG} *[{last_thinking_text}]*"
+                         resp_msg = full_response or f"{THINKING_MSG} *[{last_thinking_text}]*"
                     else:
                          resp_msg = full_response or THINKING_MSG
                 else:

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -120,6 +120,7 @@ class MattermostBridge:
         thinking_post = None
         full_response = ""
         thinking_trace = ""
+        last_thinking_text = ""
         last_update_time = 0
 
         # Create an initial thinking post to show immediate feedback
@@ -129,8 +130,10 @@ class MattermostBridge:
         async for update in goose.prompt(sid, msg):
             if update["type"] == "thinking":
                 thinking_trace += update["text"]
+                last_thinking_text = update["text"].strip()
             elif update["type"] == "tool":
                 thinking_trace += f"\n\n**Using tool**: `{update['name']}`\n"
+                last_thinking_text = f"Using tool: {update['name']}"
 
             if len(thinking_trace) > 10000:
                 thinking_trace = "... (truncated) ...\n" + thinking_trace[-8000:]
@@ -149,15 +152,22 @@ class MattermostBridge:
             if should_update:
                 resp_msg = ""
                 props = {}
+                
+                # Determine the message content
                 if update["type"] != "final":
-                    # Show content if available, otherwise "Thinking..."
-                    resp_msg = full_response or THINKING_MSG
-                    if self.config.goose_thinking_trace and thinking_trace:
-                        props = {"attachments": [{"text": thinking_trace, "title": "Thinking Trace", "color": "#9b9b9b"}]}
+                    # While thinking/streaming
+                    if self.config.goose_thinking_trace_simplified and last_thinking_text:
+                         # Simplified mode: Thinking... [Last action]
+                         resp_msg = f"{full_response or THINKING_MSG} *[{last_thinking_text}]*"
+                    else:
+                         resp_msg = full_response or THINKING_MSG
                 else:
+                    # Final response
                     resp_msg = full_response
-                    if self.config.goose_thinking_trace and thinking_trace:
-                        props = {"attachments": [{"text": thinking_trace, "title": "Thinking Trace", "color": "#9b9b9b"}]}
+
+                # Determine if we add attachments
+                if self.config.goose_thinking_trace and thinking_trace and not self.config.goose_thinking_trace_simplified:
+                    props = {"attachments": [{"text": thinking_trace, "title": "Thinking Trace", "color": "#9b9b9b"}]}
 
                 if not thinking_post:
                     thinking_post = await self.api.create_post(channel_id, resp_msg, root_id=root_id, props=props)

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -133,7 +133,6 @@ class MattermostBridge:
                 last_thinking_text = update["text"].strip()
             elif update["type"] == "tool":
                 thinking_trace += f"\n\n**Using tool**: `{update['name']}`\n"
-                last_thinking_text = f"Using tool: {update['name']}"
 
             if len(thinking_trace) > 10000:
                 thinking_trace = "... (truncated) ...\n" + thinking_trace[-8000:]

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -13,6 +13,7 @@ def mock_api():
     api = MagicMock()
     api.get_me = AsyncMock(return_value={"id": "bot_id", "username": "bot"})
     api.create_post = AsyncMock(return_value={"id": "post_id"})
+    api.update_post = AsyncMock()
     api.get_user = AsyncMock(return_value={"username": "user1"})
     return api
 
@@ -252,3 +253,28 @@ async def test_user_mapping_edge_cases(config, mock_api):
     with patch('mattermost_bridge.load_user_mapping', return_value={"user1": "linux1"}):
         await bridge._process_post(post, {"c1": {"type": "D"}})
         assert not mock_api.create_post.called
+
+
+@pytest.mark.asyncio
+async def test_thinking_trace_truncation(config, mock_api):
+    client = MagicMock()
+    async def long_thinking_gen(sid, msg):
+        yield {"type": "thinking", "text": "A" * 12000}
+        yield {"type": "final", "text": "done"}
+    
+    client.prompt.side_effect = long_thinking_gen
+    bridge = MattermostBridge(api=mock_api, config=config)
+    
+    # Ensure full trace is used (not simplified)
+    config.goose_thinking_trace_simplified = False
+    
+    await bridge._stream_response_to_mattermost(client, "sid", "msg", "cid", "rid")
+    
+    # Check that update_post was called with truncated attachments
+    update_calls = [c for c in mock_api.update_post.call_args_list if "attachments" in c[1].get("props", {})]
+    assert len(update_calls) > 0
+    
+    last_trace = update_calls[-1][1]["props"]["attachments"][0]["text"]
+    assert "... (truncated) ..." in last_trace
+    assert len(last_trace) < 10000
+

--- a/tests/test_simplified_thinking.py
+++ b/tests/test_simplified_thinking.py
@@ -1,0 +1,58 @@
+import pytest
+import asyncio
+import time
+from unittest.mock import MagicMock, AsyncMock, patch
+from mattermost_bridge import MattermostBridge
+from config import Config
+
+@pytest.fixture
+def config():
+    c = Config(mattermost_url="example.com", mattermost_token="token")
+    c.goose_thinking_trace = True
+    c.goose_thinking_trace_simplified = True
+    return c
+
+@pytest.fixture
+def mock_api():
+    api = MagicMock()
+    api.get_me = AsyncMock(return_value={"id": "bot_id", "username": "bot"})
+    api.create_post = AsyncMock(return_value={"id": "post_id"})
+    api.update_post = AsyncMock()
+    api.get_user = AsyncMock(return_value={"username": "user1"})
+    return api
+
+@pytest.mark.asyncio
+async def test_simplified_thinking_trace(config, mock_api):
+    client = MagicMock()
+    async def mock_prompt_gen(sid, msg):
+        yield {"type": "thinking", "text": "searching for files"}
+        await asyncio.sleep(0.1)
+        yield {"type": "tool", "name": "shell"}
+        await asyncio.sleep(0.1)
+        yield {"type": "final", "text": "found it"}
+    
+    client.prompt.side_effect = mock_prompt_gen
+    
+    bridge = MattermostBridge(api=mock_api, config=config)
+    
+    # Use a side_effect that increments time to ensure we cross the 1.0s threshold
+    current_time = [1000.0]
+    def increment_time():
+        current_time[0] += 1.1
+        return current_time[0]
+
+    with patch('time.time', side_effect=increment_time):
+        await bridge._stream_response_to_mattermost(client, "sid", "msg", "cid", "rid")
+    
+    calls = mock_api.update_post.call_args_list
+    msgs = [c[0][1] for c in calls]
+    print(f"Captured messages: {msgs}")
+    
+    # We expect at least one thinking update and the final one.
+    # Depending on exactly when increment_time is called, we might get more.
+    assert any("Thinking...** *[searching for files]*" in m for m in msgs) or any("Thinking...** *[Using tool: shell]*" in m for m in msgs)
+    assert "found it" in msgs
+    
+    for call in calls[:-1]:
+        props = call[1].get("props", {})
+        assert "attachments" not in props


### PR DESCRIPTION
Addresses #38 by adding a simplified mode for live thinking trace. When GOOSE_THINKING_TRACE_SIMPLIFIED is enabled, the last thinking step is shown in the message body instead of as an attachment.\n\nFixes #38.