### PR TITLE
feat(mcp): add pagination support to search_messages tool

### DIFF
--- a/src/mattermost_api.py
+++ b/src/mattermost_api.py
@@ -100,8 +100,12 @@ class MattermostAPI:
                            page: int = 0,
                            per_page: int = 60) -> Optional[Dict[str, Any]]:
         return await self._request(
-            f"/teams/{team_id}/posts/search?page={page}&per_page={per_page}",
-            data={"terms": terms},
+            f"/teams/{team_id}/posts/search",
+            data={
+                "terms": terms,
+                "page": page,
+                "per_page": per_page
+            },
             method="POST")
 
     async def search_users(self, term: str) -> Optional[list]:

--- a/src/mattermost_api.py
+++ b/src/mattermost_api.py
@@ -94,11 +94,15 @@ class MattermostAPI:
             query += f"&fromCreateAt={from_create_at}"
         return await self._request(f"/posts/{post_id}/thread?{query}")
 
-    async def search_posts(self, team_id: str,
-                           terms: str) -> Optional[Dict[str, Any]]:
-        return await self._request(f"/teams/{team_id}/posts/search",
-                                   data={"terms": terms},
-                                   method="POST")
+    async def search_posts(self,
+                           team_id: str,
+                           terms: str,
+                           page: int = 0,
+                           per_page: int = 60) -> Optional[Dict[str, Any]]:
+        return await self._request(
+            f"/teams/{team_id}/posts/search?page={page}&per_page={per_page}",
+            data={"terms": terms},
+            method="POST")
 
     async def search_users(self, term: str) -> Optional[list]:
         return await self._request("/users/search",

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -117,11 +117,15 @@ class MattermostMCPServer:
             return "\n".join(formatted)
 
         @self.mcp.tool()
-        async def search_messages(terms: str) -> str:
+        async def search_messages(terms: str,
+                                  page: int = 0,
+                                  per_page: int = 60) -> str:
             """Search for messages across Mattermost.
             
             Args:
                 terms: Search terms.
+                page: Optional page number (defaults to 0).
+                per_page: Optional number of results per page (defaults to 60).
             """
             teams = await self.bridge.api.get_my_teams()
             if not teams:
@@ -129,7 +133,10 @@ class MattermostMCPServer:
 
             all_results = []
             for team in teams:
-                results = await self.bridge.api.search_posts(team["id"], terms)
+                results = await self.bridge.api.search_posts(team["id"],
+                                                             terms,
+                                                             page=page,
+                                                             per_page=per_page)
                 if results and "posts" in results:
                     all_results.extend(results["posts"].values())
 
@@ -138,7 +145,7 @@ class MattermostMCPServer:
 
             all_results.sort(key=lambda x: x["create_at"], reverse=True)
             formatted = []
-            for p in all_results[:20]:
+            for p in all_results[:per_page]:
                 formatted.append(
                     f"[Post ID: {p['id']}] [Channel ID: {p['channel_id']}] {p['message']}"
                 )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -110,7 +110,10 @@ async def test_call_tool_search_messages(mcp_server, mock_bridge):
 
     assert len(result) == 1
     assert "found it" in result[0].text
-    mock_bridge.api.search_posts.assert_called_once_with("t1", "query")
+    mock_bridge.api.search_posts.assert_called_once_with("t1",
+                                                        "query",
+                                                        page=0,
+                                                        per_page=60)
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -111,9 +111,9 @@ async def test_call_tool_search_messages(mcp_server, mock_bridge):
     assert len(result) == 1
     assert "found it" in result[0].text
     mock_bridge.api.search_posts.assert_called_once_with("t1",
-                                                        "query",
-                                                        page=0,
-                                                        per_page=60)
+                                                         "query",
+                                                         page=0,
+                                                         per_page=60)
 
 
 @pytest.mark.asyncio

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
+import json
 
 import pytest
 
@@ -106,8 +107,15 @@ async def test_api_search_posts_pagination(api):
         args, _ = mock_url.call_args
         req = args[0]
         url = req.get_full_url()
-        assert "page=2" in url
-        assert "per_page=10" in url
+        # Check that page and per_page are NOT in the URL as query params
+        assert "page=2" not in url
+        assert "per_page=10" not in url
+
+        # Check that they ARE in the data (body)
+        data = json.loads(req.data.decode())
+        assert data["page"] == 2
+        assert data["per_page"] == 10
+        assert data["terms"] == "query"
 
 
 @pytest.mark.asyncio

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,7 +1,7 @@
+import json
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
-import json
 
 import pytest
 
@@ -15,21 +15,27 @@ def api():
     config = Config(mattermost_url="example.com", mattermost_token="token")
     return MattermostAPI(config=config)
 
+
 @pytest.mark.asyncio
 async def test_api_get_thread_pagination(api):
     mock_response = MagicMock()
     mock_response.read.return_value = b'{"posts": {"p1": {"id": "p1"}}, "order": ["p1"]}'
     mock_response.__enter__.return_value = mock_response
 
-    with patch('urllib.request.urlopen', return_value=mock_response) as mock_url:
-        await api.get_thread("post123", per_page=10, from_create_at=12345, direction="up")
-        
+    with patch('urllib.request.urlopen',
+               return_value=mock_response) as mock_url:
+        await api.get_thread("post123",
+                             per_page=10,
+                             from_create_at=12345,
+                             direction="up")
+
         args, _ = mock_url.call_args
         req = args[0]
         url = req.get_full_url()
         assert "perPage=10" in url
         assert "fromCreateAt=12345" in url
         assert "direction=up" in url
+
 
 @pytest.fixture
 def mock_bridge():
@@ -38,62 +44,101 @@ def mock_bridge():
     bridge.api.get_user = AsyncMock(return_value={"username": "testuser"})
     return bridge
 
+
 @pytest.fixture
 def mcp_server(mock_bridge):
     return MattermostMCPServer(mock_bridge)
 
+
 @pytest.mark.asyncio
 async def test_mcp_get_thread_context_with_limit(mcp_server, mock_bridge):
     # Mock a thread with 10 posts
-    posts = {f"p{i}": {"message": f"m{i}", "create_at": i, "user_id": "u1"} for i in range(10)}
+    posts = {
+        f"p{i}": {
+            "message": f"m{i}",
+            "create_at": i,
+            "user_id": "u1"
+        } for i in range(10)
+    }
     order = [f"p{i}" for i in range(10)]
-    
+
     mock_bridge.api.get_thread = AsyncMock(return_value={
         "posts": posts,
         "order": order,
         "has_next": False
     })
-    
+
     # Test limit=2, page=0 (should be the last 2 posts: m8, m9)
-    result_list, _ = await mcp_server.mcp.call_tool("get_thread_context", {"root_id": "r1", "limit": 2, "page": 0})
+    result_list, _ = await mcp_server.mcp.call_tool("get_thread_context", {
+        "root_id": "r1",
+        "limit": 2,
+        "page": 0
+    })
     result = result_list[0].text
     assert "m8" in result and "m9" in result
     assert "m7" not in result
     assert result.count('m') == 2
-    
+
     # Test limit=2, page=1 (should be m6, m7)
-    result_list, _ = await mcp_server.mcp.call_tool("get_thread_context", {"root_id": "r1", "limit": 2, "page": 1})
+    result_list, _ = await mcp_server.mcp.call_tool("get_thread_context", {
+        "root_id": "r1",
+        "limit": 2,
+        "page": 1
+    })
     result = result_list[0].text
     assert "m6" in result and "m7" in result
     assert "m8" not in result
     assert result.count('m') == 2
 
+
 @pytest.mark.asyncio
 async def test_mcp_get_thread_context_all_pages(mcp_server, mock_bridge):
     # Mock multiple pages (direction="up")
     page1 = {
-        "posts": {f"p{i}": {"message": f"m{i}", "create_at": i, "user_id": "u1"} for i in range(0, 60)},
+        "posts": {
+            f"p{i}": {
+                "message": f"m{i}",
+                "create_at": i,
+                "user_id": "u1"
+            } for i in range(0, 60)
+        },
         "order": [f"p{i}" for i in range(0, 60)],
         "has_next": True
     }
     page2 = {
-        "posts": {f"p{i}": {"message": f"m{i}", "create_at": i, "user_id": "u1"} for i in range(60, 120)},
+        "posts": {
+            f"p{i}": {
+                "message": f"m{i}",
+                "create_at": i,
+                "user_id": "u1"
+            } for i in range(60, 120)
+        },
         "order": [f"p{i}" for i in range(60, 120)],
         "has_next": False
     }
-    
+
     mock_bridge.api.get_thread = AsyncMock(side_effect=[page1, page2])
-    
-    result_list, _ = await mcp_server.mcp.call_tool("get_thread_context", {"root_id": "r1", "limit": 0})
+
+    result_list, _ = await mcp_server.mcp.call_tool("get_thread_context", {
+        "root_id": "r1",
+        "limit": 0
+    })
     result = result_list[0].text
-    
+
     # With limit=0, it should only call once with per_page=0
     assert mock_bridge.api.get_thread.call_count == 2
     assert result.count("[Sender: @testuser]") == 120
-    
+
     # Verify call arguments
-    mock_bridge.api.get_thread.assert_any_call("r1", per_page=0, from_create_at=0, direction="up")
-    mock_bridge.api.get_thread.assert_any_call("r1", per_page=0, from_create_at=59, direction="up")
+    mock_bridge.api.get_thread.assert_any_call("r1",
+                                               per_page=0,
+                                               from_create_at=0,
+                                               direction="up")
+    mock_bridge.api.get_thread.assert_any_call("r1",
+                                               per_page=0,
+                                               from_create_at=59,
+                                               direction="up")
+
 
 @pytest.mark.asyncio
 async def test_api_search_posts_pagination(api):
@@ -101,7 +146,8 @@ async def test_api_search_posts_pagination(api):
     mock_response.read.return_value = b'{"posts": {"p1": {"id": "p1"}}}'
     mock_response.__enter__.return_value = mock_response
 
-    with patch('urllib.request.urlopen', return_value=mock_response) as mock_url:
+    with patch('urllib.request.urlopen',
+               return_value=mock_response) as mock_url:
         await api.search_posts("team123", "query", page=2, per_page=10)
 
         args, _ = mock_url.call_args
@@ -121,26 +167,26 @@ async def test_api_search_posts_pagination(api):
 @pytest.mark.asyncio
 async def test_mcp_search_messages_pagination(mcp_server, mock_bridge):
     mock_bridge.api.get_my_teams = AsyncMock(return_value=[{"id": "t1"}])
-    mock_bridge.api.search_posts = AsyncMock(return_value={
-        "posts": {
-            "p1": {
-                "id": "p1",
-                "channel_id": "c1",
-                "message": "found it",
-                "create_at": 100
+    mock_bridge.api.search_posts = AsyncMock(
+        return_value={
+            "posts": {
+                "p1": {
+                    "id": "p1",
+                    "channel_id": "c1",
+                    "message": "found it",
+                    "create_at": 100
+                }
             }
-        }
-    })
-
-    result_list, _ = await mcp_server.mcp.call_tool(
-        "search_messages", {
-            "terms": "query",
-            "page": 1,
-            "per_page": 5
         })
+
+    result_list, _ = await mcp_server.mcp.call_tool("search_messages", {
+        "terms": "query",
+        "page": 1,
+        "per_page": 5
+    })
 
     assert "found it" in result_list[0].text
     mock_bridge.api.search_posts.assert_called_once_with("t1",
-                                                        "query",
-                                                        page=1,
-                                                        per_page=5)
+                                                         "query",
+                                                         page=1,
+                                                         per_page=5)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -95,22 +95,44 @@ async def test_mcp_get_thread_context_all_pages(mcp_server, mock_bridge):
     mock_bridge.api.get_thread.assert_any_call("r1", per_page=0, from_create_at=59, direction="up")
 
 @pytest.mark.asyncio
-async def test_mcp_get_thread_context_limit_optimization(mcp_server, mock_bridge):
-    # Mock a response that has more than (page+1)*limit + 1 posts
-    # limit=2, page=0 => threshold is 3 posts.
-    posts = {f"p{i}": {"message": f"m{i}", "create_at": i, "user_id": "u1"} for i in range(5)}
-    order = [f"p{i}" for i in range(5)]
-    
-    mock_bridge.api.get_thread = AsyncMock(return_value={
-        "posts": posts,
-        "order": order,
-        "has_next": True
+async def test_api_search_posts_pagination(api):
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"posts": {"p1": {"id": "p1"}}}'
+    mock_response.__enter__.return_value = mock_response
+
+    with patch('urllib.request.urlopen', return_value=mock_response) as mock_url:
+        await api.search_posts("team123", "query", page=2, per_page=10)
+
+        args, _ = mock_url.call_args
+        req = args[0]
+        url = req.get_full_url()
+        assert "page=2" in url
+        assert "per_page=10" in url
+
+
+@pytest.mark.asyncio
+async def test_mcp_search_messages_pagination(mcp_server, mock_bridge):
+    mock_bridge.api.get_my_teams = AsyncMock(return_value=[{"id": "t1"}])
+    mock_bridge.api.search_posts = AsyncMock(return_value={
+        "posts": {
+            "p1": {
+                "id": "p1",
+                "channel_id": "c1",
+                "message": "found it",
+                "create_at": 100
+            }
+        }
     })
-    
-    result_list, _ = await mcp_server.mcp.call_tool("get_thread_context", {"root_id": "r1", "limit": 2, "page": 0})
-    
-    # Should only call get_thread once because we already have 5 posts, which is >= 3
-    assert mock_bridge.api.get_thread.call_count == 1
-    result = result_list[0].text
-    assert "m3" in result and "m4" in result
-    assert "m2" not in result
+
+    result_list, _ = await mcp_server.mcp.call_tool(
+        "search_messages", {
+            "terms": "query",
+            "page": 1,
+            "per_page": 5
+        })
+
+    assert "found it" in result_list[0].text
+    mock_bridge.api.search_posts.assert_called_once_with("t1",
+                                                        "query",
+                                                        page=1,
+                                                        per_page=5)


### PR DESCRIPTION
This PR adds pagination support to the search_messages tool by adding page and per_page parameters.