### PR TITLE
feat: add attachment support and post metadata retrieval

### DIFF
--- a/src/mattermost_api.py
+++ b/src/mattermost_api.py
@@ -2,7 +2,7 @@ import asyncio
 from datetime import datetime
 import json
 import ssl
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 import urllib.error
 import urllib.request
 
@@ -56,6 +56,26 @@ class MattermostAPI:
             print(f"[{datetime.now()}] MM Request Error ({method} {path}): {e}")
             return None
 
+    async def _request_raw(self,
+                           path: str,
+                           method: str = "GET") -> Optional[bytes]:
+        """Makes an asynchronous request to the Mattermost API and returns raw bytes."""
+        return await asyncio.to_thread(self._sync_request_raw, path, method)
+
+    def _sync_request_raw(self, path: str, method: str) -> Optional[bytes]:
+        """Makes a synchronous request to the Mattermost API and returns raw bytes."""
+        url = f"{self.base_url}{path}"
+        req = urllib.request.Request(url, headers=self.headers, method=method)
+        try:
+            with urllib.request.urlopen(req,
+                                        context=self.ssl_context) as response:
+                return response.read()
+        except Exception as e:
+            print(
+                f"[{datetime.now()}] MM Raw Request Error ({method} {path}): {e}"
+            )
+            return None
+
     async def get_me(self) -> Optional[Dict[str, Any]]:
         return await self._request("/users/me")
 
@@ -75,6 +95,10 @@ class MattermostAPI:
                                 since: int) -> Optional[Dict[str, Any]]:
         return await self._request(f"/channels/{channel_id}/posts?since={since}"
                                   )
+
+    async def get_post(self, post_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch a single post by ID."""
+        return await self._request(f"/posts/{post_id}")
 
     async def get_thread(self,
                          post_id: str,
@@ -143,3 +167,11 @@ class MattermostAPI:
         if props:
             data["props"] = props
         return await self._request(f"/posts/{post_id}", data=data, method="PUT")
+
+    async def get_file_info(self, file_id: str) -> Optional[Dict[str, Any]]:
+        """Get metadata for a file."""
+        return await self._request(f"/files/{file_id}/info")
+
+    async def download_file(self, file_id: str) -> Optional[bytes]:
+        """Download a file's raw data."""
+        return await self._request_raw(f"/files/{file_id}")

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -112,7 +112,14 @@ class MattermostMCPServer:
             formatted = []
             for p in posts:
                 username = user_map.get(p["user_id"], "unknown")
-                formatted.append(f"[Sender: @{username}] {p['message']}")
+                msg = p.get('message', '')
+                
+                # Add attachment indicator
+                file_ids = p.get('file_ids', [])
+                if file_ids:
+                    msg = f"[Has {len(file_ids)} attachment(s)] {msg}"
+                
+                formatted.append(f"[Sender: @{username}] {msg}")
 
             return "\n".join(formatted)
 
@@ -204,6 +211,66 @@ class MattermostMCPServer:
 
             await self.bridge.api.create_post(channel["id"], message)
             return f"Direct message sent to channel {channel['id']}"
+
+        @self.mcp.tool()
+        async def get_post_details(post_id: str) -> str:
+            """Retrieve the full metadata for a specific post, including attachment IDs.
+            
+            Args:
+                post_id: The ID of the post to retrieve.
+            """
+            post = await self.bridge.api.get_post(post_id)
+            if not post:
+                return f"Post {post_id} not found"
+            return json.dumps(post, indent=2)
+
+        @self.mcp.tool()
+        async def list_post_attachments(post_id: str) -> str:
+            """List names and IDs of files attached to a post.
+            
+            Args:
+                post_id: The ID of the post.
+            """
+            post = await self.bridge.api.get_post(post_id)
+            if not post or 'file_ids' not in post or not post['file_ids']:
+                return "No attachments found for this post"
+            
+            attachments = []
+            for fid in post['file_ids']:
+                info = await self.bridge.api.get_file_info(fid)
+                if info:
+                    attachments.append({
+                        "id": fid,
+                        "name": info.get("name", "unknown"),
+                        "extension": info.get("extension", ""),
+                        "size": info.get("size", 0)
+                    })
+                else:
+                    attachments.append({"id": fid, "name": "unknown"})
+            
+            return json.dumps(attachments, indent=2)
+
+        @self.mcp.tool()
+        async def download_attachment(file_id: str, destination_path: str) -> str:
+            """Download an attachment from Mattermost to the local filesystem.
+            
+            Args:
+                file_id: The ID of the file to download.
+                destination_path: The local path where the file should be saved.
+            """
+            data = await self.bridge.api.download_file(file_id)
+            if not data:
+                return "Failed to download file"
+            
+            try:
+                import os
+                # Ensure directory exists
+                os.makedirs(os.path.dirname(os.path.abspath(destination_path)), exist_ok=True)
+                with open(destination_path, "wb") as f:
+                    f.write(data)
+                return f"File downloaded successfully to {destination_path}"
+            except Exception as e:
+                return f"Error saving file: {str(e)}"
 
     async def run(self, host: str, port: int):
         """Run the MCP server using Streamable HTTP transport."""

--- a/tests/test_mattermost_api.py
+++ b/tests/test_mattermost_api.py
@@ -55,6 +55,7 @@ async def test_api_http_error(api):
 
         res = await api.get_me()
         assert res is None
+
 @pytest.mark.asyncio
 async def test_get_user(api):
     mock_response = MagicMock()
@@ -65,6 +66,38 @@ async def test_get_user(api):
         user = await api.get_user("u1")
         assert user["id"] == "u1"
         assert user["username"] == "user1"
+
+@pytest.mark.asyncio
+async def test_get_post(api):
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"id": "p1", "message": "hello"}'
+    mock_response.__enter__.return_value = mock_response
+
+    with patch('urllib.request.urlopen', return_value=mock_response):
+        post = await api.get_post("p1")
+        assert post["id"] == "p1"
+        assert post["message"] == "hello"
+
+@pytest.mark.asyncio
+async def test_get_file_info(api):
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"id": "f1", "name": "test.txt"}'
+    mock_response.__enter__.return_value = mock_response
+
+    with patch('urllib.request.urlopen', return_value=mock_response):
+        info = await api.get_file_info("f1")
+        assert info["id"] == "f1"
+        assert info["name"] == "test.txt"
+
+@pytest.mark.asyncio
+async def test_download_file(api):
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'raw file data'
+    mock_response.__enter__.return_value = mock_response
+
+    with patch('urllib.request.urlopen', return_value=mock_response):
+        data = await api.download_file("f1")
+        assert data == b'raw file data'
 
 @pytest.mark.asyncio
 async def test_get_direct_channels(api):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,7 @@
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import mock_open
 
 import pytest
 
@@ -24,7 +26,7 @@ def mcp_server(mock_bridge):
 @pytest.mark.asyncio
 async def test_list_tools(mcp_server):
     tools = await mcp_server.mcp.list_tools()
-    assert len(tools) == 7
+    assert len(tools) == 10
     tool_names = [t.name for t in tools]
     assert "send_message" in tool_names
     assert "get_channels" in tool_names
@@ -33,6 +35,9 @@ async def test_list_tools(mcp_server):
     assert "search_users" in tool_names
     assert "get_user_info" in tool_names
     assert "send_direct_message" in tool_names
+    assert "get_post_details" in tool_names
+    assert "list_post_attachments" in tool_names
+    assert "download_attachment" in tool_names
 
 
 @pytest.mark.asyncio
@@ -65,7 +70,8 @@ async def test_call_tool_get_thread_context(mcp_server, mock_bridge):
                 "p1": {
                     "message": "first",
                     "create_at": 100,
-                    "user_id": "u1"
+                    "user_id": "u1",
+                    "file_ids": ["f1"]
                 },
                 "p2": {
                     "message": "second",
@@ -81,9 +87,8 @@ async def test_call_tool_get_thread_context(mcp_server, mock_bridge):
                                                {"root_id": "r1"})
 
     assert len(result) == 1
-    assert "[Sender: @user_u1] first" in result[0].text
+    assert "[Sender: @user_u1] [Has 1 attachment(s)] first" in result[0].text
     assert "[Sender: @user_u2] second" in result[0].text
-    # Now called with per_page=60, from_create_at=0, direction="down" by default in the pagination loop
     mock_bridge.api.get_thread.assert_any_call("r1",
                                                per_page=0,
                                                from_create_at=0,
@@ -133,7 +138,6 @@ async def test_call_tool_send_direct_message(mcp_server, mock_bridge):
 
     assert "Direct message sent" in result[0].text
     mock_bridge.api.create_direct_channel.assert_called_once()
-    # Should include both user1 and me
     user_ids = mock_bridge.api.create_direct_channel.call_args[0][0]
     assert "u1_id" in user_ids
     assert "me_id" in user_ids
@@ -144,6 +148,7 @@ async def test_call_tool_unknown(mcp_server):
     from mcp.server.fastmcp.exceptions import ToolError
     with pytest.raises(ToolError, match="Unknown tool: ghost_tool"):
         await mcp_server.mcp.call_tool("ghost_tool", {})
+
 @pytest.mark.asyncio
 async def test_call_tool_search_users(mcp_server, mock_bridge):
     mock_bridge.api.search_users = AsyncMock(return_value=[{"id": "u1", "username": "user1"}])
@@ -163,3 +168,37 @@ async def test_call_tool_get_user_info(mcp_server, mock_bridge):
     assert len(result) == 1
     assert "user1@example.com" in result[0].text
     mock_bridge.api.get_user.assert_called_once_with("u1")
+
+@pytest.mark.asyncio
+async def test_call_tool_get_post_details(mcp_server, mock_bridge):
+    mock_bridge.api.get_post = AsyncMock(return_value={"id": "p1", "file_ids": ["f1"]})
+    
+    result, _ = await mcp_server.mcp.call_tool("get_post_details", {"post_id": "p1"})
+    
+    assert "f1" in result[0].text
+    mock_bridge.api.get_post.assert_called_once_with("p1")
+
+@pytest.mark.asyncio
+async def test_call_tool_list_post_attachments(mcp_server, mock_bridge):
+    mock_bridge.api.get_post = AsyncMock(return_value={"id": "p1", "file_ids": ["f1"]})
+    mock_bridge.api.get_file_info = AsyncMock(return_value={"id": "f1", "name": "test.png"})
+    
+    result, _ = await mcp_server.mcp.call_tool("list_post_attachments", {"post_id": "p1"})
+    
+    assert "test.png" in result[0].text
+    mock_bridge.api.get_file_info.assert_called_once_with("f1")
+
+@pytest.mark.asyncio
+async def test_call_tool_download_attachment(mcp_server, mock_bridge):
+    mock_bridge.api.download_file = AsyncMock(return_value=b"content")
+    
+    with patch("builtins.open", mock_open()) as mocked_file:
+        with patch("os.makedirs"):
+            result, _ = await mcp_server.mcp.call_tool("download_attachment", {
+                "file_id": "f1",
+                "destination_path": "/tmp/test.png"
+            })
+            
+            assert "successfully" in result[0].text
+            mock_bridge.api.download_file.assert_called_once_with("f1")
+            mocked_file.assert_called_once_with("/tmp/test.png", "wb")


### PR DESCRIPTION
This PR implements the plan outlined in issue #46 to add support for discovering and downloading file attachments from Mattermost.

### Changes:
- **API Enhancements (`src/mattermost_api.py`)**: 
    - Added `get_post(post_id)` to retrieve full post metadata.
    - Added `get_file_info(file_id)` to get attachment details (name, size).
    - Added `download_file(file_id)` and a new `_request_raw` method to handle binary file downloads.
- **New MCP Tools (`src/mcp_server.py`)**:
    - `get_post_details(post_id)`: Returns full JSON metadata for a post.
    - `list_post_attachments(post_id)`: Lists name, ID, and size of all attachments for a post.
    - `download_attachment(file_id, destination_path)`: Directly saves a Mattermost attachment to the local filesystem.
- **Context Enrichment**:
    - Updated `get_thread_context` to automatically prefix messages that have attachments with a `[Has N attachment(s)]` indicator.

Fixes #46