### PR TITLE
feat: add support for file attachments

### DIFF
--- a/src/mattermost_api.py
+++ b/src/mattermost_api.py
@@ -1,10 +1,13 @@
 import asyncio
 from datetime import datetime
 import json
+import mimetypes
+import os
 import ssl
 from typing import Any, Dict, Optional, Union
 import urllib.error
 import urllib.request
+import uuid
 
 from config import default_config
 
@@ -148,12 +151,15 @@ class MattermostAPI:
             channel_id: str,
             message: str,
             root_id: Optional[str] = None,
+            file_ids: Optional[list] = None,
             props: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
         data = {
             "channel_id": channel_id,
             "message": message,
             "root_id": root_id
         }
+        if file_ids:
+            data["file_ids"] = file_ids
         if props:
             data["props"] = props
         return await self._request("/posts", data=data, method="POST")
@@ -175,3 +181,58 @@ class MattermostAPI:
     async def download_file(self, file_id: str) -> Optional[bytes]:
         """Download a file's raw data."""
         return await self._request_raw(f"/files/{file_id}")
+
+    async def upload_file(self, channel_id: str, file_path: str) -> Optional[Dict[str, Any]]:
+        """Upload a file to a channel.
+        
+        Args:
+            channel_id: The ID of the channel to upload the file to.
+            file_path: The local path of the file to upload.
+        """
+        return await asyncio.to_thread(self._sync_upload_file, channel_id, file_path)
+
+    def _sync_upload_file(self, channel_id: str, file_path: str) -> Optional[Dict[str, Any]]:
+        """Synchronously upload a file to a channel."""
+        if not os.path.exists(file_path):
+            print(f"File not found: {file_path}")
+            return None
+
+        filename = os.path.basename(file_path)
+        mime_type, _ = mimetypes.guess_type(file_path)
+        mime_type = mime_type or 'application/octet-stream'
+
+        boundary = f"----WebKitFormBoundary{uuid.uuid4().hex}"
+        
+        with open(file_path, 'rb') as f:
+            file_content = f.read()
+
+        # Build multipart/form-data
+        parts = []
+        parts.append(f'--{boundary}'.encode())
+        parts.append(f'Content-Disposition: form-data; name="channel_id"'.encode())
+        parts.append(b'')
+        parts.append(channel_id.encode())
+        
+        parts.append(f'--{boundary}'.encode())
+        parts.append(f'Content-Disposition: form-data; name="files"; filename="{filename}"'.encode())
+        parts.append(f'Content-Type: {mime_type}'.encode())
+        parts.append(b'')
+        parts.append(file_content)
+        
+        parts.append(f'--{boundary}--'.encode())
+        parts.append(b'')
+        
+        body = b'\r\n'.join(parts)
+        
+        url = f"{self.base_url}/files"
+        headers = self.headers.copy()
+        headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
+        headers["Content-Length"] = str(len(body))
+        
+        req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, context=self.ssl_context) as response:
+                return json.loads(response.read().decode())
+        except Exception as e:
+            print(f"[{datetime.now()}] MM Upload Error: {e}")
+            return None

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -17,18 +17,29 @@ class MattermostMCPServer:
         @self.mcp.tool()
         async def send_message(channel_id: str,
                                message: str,
-                               root_id: Optional[str] = None) -> str:
+                               root_id: Optional[str] = None,
+                               file_path: Optional[str] = None) -> str:
             """Send a message to a Mattermost channel.
             
             Args:
                 channel_id: The ID of the channel to send the message to.
                 message: The message text.
                 root_id: Optional thread root ID to reply to a specific thread.
+                file_path: Optional local path to a file to attach to the message.
             """
+            file_ids = None
+            if file_path:
+                upload_result = await self.bridge.api.upload_file(channel_id, file_path)
+                if upload_result and "file_infos" in upload_result and upload_result["file_infos"]:
+                    file_ids = [info["id"] for info in upload_result["file_infos"]]
+                else:
+                    return f"Failed to upload attachment: {file_path}"
+
             await self.bridge.api.create_post(channel_id,
                                               message,
-                                              root_id=root_id)
-            return "Message sent successfully"
+                                              root_id=root_id,
+                                              file_ids=file_ids)
+            return "Message sent successfully" + (" with attachment" if file_ids else "")
 
         @self.mcp.tool()
         async def get_channels() -> str:
@@ -181,12 +192,14 @@ class MattermostMCPServer:
 
         @self.mcp.tool()
         async def send_direct_message(usernames: List[str],
-                                      message: str) -> str:
+                                      message: str,
+                                      file_path: Optional[str] = None) -> str:
             """Send a direct message to one or more users.
             
             Args:
                 usernames: List of usernames (with or without @).
                 message: The message text.
+                file_path: Optional local path to a file to attach.
             """
             user_ids = []
             for uname in usernames:
@@ -209,8 +222,16 @@ class MattermostMCPServer:
             if not channel:
                 return "Failed to create direct channel"
 
-            await self.bridge.api.create_post(channel["id"], message)
-            return f"Direct message sent to channel {channel['id']}"
+            file_ids = None
+            if file_path:
+                upload_result = await self.bridge.api.upload_file(channel["id"], file_path)
+                if upload_result and "file_infos" in upload_result and upload_result["file_infos"]:
+                    file_ids = [info["id"] for info in upload_result["file_infos"]]
+                else:
+                    return f"Failed to upload attachment: {file_path}"
+
+            await self.bridge.api.create_post(channel["id"], message, file_ids=file_ids)
+            return f"Direct message sent to channel {channel['id']}" + (" with attachment" if file_ids else "")
 
         @self.mcp.tool()
         async def get_post_details(post_id: str) -> str:

--- a/tests/test_mattermost_api.py
+++ b/tests/test_mattermost_api.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, mock_open
 from unittest.mock import patch
 import urllib.error
 
@@ -205,3 +205,19 @@ async def test_update_post(api):
         assert res["message"] == "updated"
         req = mock_url.call_args[0][0]
         assert req.get_method() == "PUT"
+
+@pytest.mark.asyncio
+async def test_upload_file(api):
+    mock_response = MagicMock()
+    mock_response.read.return_value = b'{"file_infos": [{"id": "f1"}]}'
+    mock_response.__enter__.return_value = mock_response
+
+    with patch('urllib.request.urlopen', return_value=mock_response) as mock_url:
+        with patch('os.path.exists', return_value=True):
+            with patch('mimetypes.guess_type', return_value=('text/plain', None)):
+                with patch('builtins.open', mock_open(read_data=b"file content")):
+                    res = await api.upload_file("c1", "test.txt")
+                    assert res["file_infos"][0]["id"] == "f1"
+                    req = mock_url.call_args[0][0]
+                    assert req.get_method() == "POST"
+                    assert "multipart/form-data" in req.get_header("Content-type")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -50,7 +50,8 @@ async def test_call_tool_send_message(mcp_server, mock_bridge):
     assert result[0].text == "Message sent successfully"
     mock_bridge.api.create_post.assert_called_once_with("c1",
                                                         "hello",
-                                                        root_id="r1")
+                                                        root_id="r1",
+                                                        file_ids=None)
 
 
 @pytest.mark.asyncio
@@ -141,6 +142,38 @@ async def test_call_tool_send_direct_message(mcp_server, mock_bridge):
     user_ids = mock_bridge.api.create_direct_channel.call_args[0][0]
     assert "u1_id" in user_ids
     assert "me_id" in user_ids
+
+
+@pytest.mark.asyncio
+async def test_call_tool_send_message_with_attachment(mcp_server, mock_bridge):
+    mock_bridge.api.upload_file = AsyncMock(return_value={"file_infos": [{"id": "f1"}]})
+    arguments = {"channel_id": "c1", "message": "hello", "file_path": "test.txt"}
+
+    result, _ = await mcp_server.mcp.call_tool("send_message", arguments)
+
+    assert "with attachment" in result[0].text
+    mock_bridge.api.upload_file.assert_called_once_with("c1", "test.txt")
+    mock_bridge.api.create_post.assert_called_once_with("c1", "hello", root_id=None, file_ids=["f1"])
+
+
+@pytest.mark.asyncio
+async def test_call_tool_send_direct_message_with_attachment(mcp_server, mock_bridge):
+    mock_bridge.api.get_me = AsyncMock(return_value={"id": "me_id"})
+    mock_bridge.api.search_users = AsyncMock(return_value=[{"id": "u1_id", "username": "user1"}])
+    mock_bridge.api.create_direct_channel = AsyncMock(return_value={"id": "dm_channel"})
+    mock_bridge.api.upload_file = AsyncMock(return_value={"file_infos": [{"id": "f1"}]})
+    
+    arguments = {
+        "usernames": ["@user1"],
+        "message": "private hello",
+        "file_path": "test.txt"
+    }
+
+    result, _ = await mcp_server.mcp.call_tool("send_direct_message", arguments)
+
+    assert "with attachment" in result[0].text
+    mock_bridge.api.upload_file.assert_called_once_with("dm_channel", "test.txt")
+    mock_bridge.api.create_post.assert_called_once_with("dm_channel", "private hello", file_ids=["f1"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR adds the ability to provide an optional `file_path` to `send_message` and `send_direct_message` tools. The bridge will handle uploading the file to Mattermost and attaching it to the post.