### PR TITLE
fix: handle tool_call_update completion chunks in ACP client

### DIFF
--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -381,8 +381,12 @@ class GooseACPClient:
             }
         elif session_update == "tool_call_update":
             title = update.get("title")
+            status = update.get("status")
             if title:
                 return {"type": "thinking", "text": title}
+            if status == "completed":
+                # Recognize completion to avoid "unknown" logs
+                return {"type": "thinking", "text": "Tool execution completed"}
         elif session_update == "usage_update":
             used = update.get("used")
             size = update.get("size")

--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -386,7 +386,7 @@ class GooseACPClient:
                 return {"type": "thinking", "text": title}
             if status == "completed":
                 # Recognize completion to avoid "unknown" logs
-                return {"type": "thinking", "text": "Tool execution completed"}
+                return {"type": "thinking", "text": "working..."}
         elif session_update == "usage_update":
             used = update.get("used")
             size = update.get("size")

--- a/tests/test_goose_acp_client.py
+++ b/tests/test_goose_acp_client.py
@@ -115,6 +115,32 @@ async def test_parse_update_chunk(client):
     assert parsed["type"] == "tool"
     assert parsed["name"] == "test_tool"
 
+    # Test tool_call_update with title
+    chunk = {
+        "method": "session/update",
+        "params": {
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "title": "Performing search..."
+            }
+        }
+    }
+    parsed = client._parse_update_chunk(chunk)
+    assert parsed == {"type": "thinking", "text": "Performing search..."}
+
+    # Test tool_call_update with completed status
+    chunk = {
+        "method": "session/update",
+        "params": {
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "status": "completed"
+            }
+        }
+    }
+    parsed = client._parse_update_chunk(chunk)
+    assert parsed == {"type": "thinking", "text": "Tool execution completed"}
+
 
 @pytest.mark.asyncio
 async def test_process_death_during_prompt(client):

--- a/tests/test_goose_acp_client.py
+++ b/tests/test_goose_acp_client.py
@@ -139,7 +139,7 @@ async def test_parse_update_chunk(client):
         }
     }
     parsed = client._parse_update_chunk(chunk)
-    assert parsed == {"type": "thinking", "text": "Tool execution completed"}
+    assert parsed == {"type": "thinking", "text": "working..."}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Explicitly handle 'tool_call_update' chunks with 'status: completed' to reduce log noise and ensure UI synchronization. Fixes #53