### PR TITLE
docs: update copyright to 2026 Matt Razza

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 @razza
+   Copyright 2026 Matt Razza
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates the copyright year to 2026 and name to Matt Razza.