### PR TITLE
fix(client): handle non-dict result under session prompt response robustly

### DIFF
--- a/src/goose_acp_client.py
+++ b/src/goose_acp_client.py
@@ -310,7 +310,7 @@ class GooseACPClient:
                         raise Exception(f"Goose error: {res['error']}")
 
                     result = res.get("result", {})
-                    stop_reason = result.get("stopReason")
+                    stop_reason = result.get("stopReason") if isinstance(result, dict) else None
 
                     full_response = await self._drain_remaining_chunks(
                         session_id, full_response)


### PR DESCRIPTION
Handle non-dict results in session prompt responses defensively to prevent AttributeErrors (e.g. when result is a string success mock in tests).