### PR TITLE
feat(bridge): add admin impersonation functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ MATTERMOST_PORT=443
 # Example: alice,bob,charlie
 APPROVED_USERS=alice,bob
 
+# Comma-separated list of Mattermost usernames or User IDs authorized as administrators.
+# Administrators can use the !impersonate command to interact in other users' sessions.
+# Format: comma-separated list of strings without spaces.
+# Example: alice,admin_user_id
+ADMIN_USERS=
+
 # How often (in seconds) the bridge polls Mattermost for new messages.
 # Format: Positive integer.
 # Default: 1

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The bridge is configured via environment variables in the `.env` file:
 | `MATTERMOST_SCHEME` | The protocol used by Mattermost (`http` or `https`). | `https` |
 | `MATTERMOST_PORT` | The port number Mattermost is listening on. | `443` |
 | `APPROVED_USERS` | A comma-separated list of usernames or user IDs authorized to use the bot. If empty, any user who can reach the bot can use it. | (None) |
+| `ADMIN_USERS` | A comma-separated list of usernames or user IDs authorized as administrators to run admin-only commands (e.g., `!impersonate`). | (None) |
 | `USER_MAPPING_FILE` | Path to the JSON configuration file for OS-level user isolation. | `user_mapping.json` |
 | `POLL_INTERVAL` | How often (in seconds) the bridge checks for new messages. | `1` |
 | `DEBUG` | Set to `true` to see detailed JSON-RPC logs for troubleshooting. | `false` |
@@ -154,6 +155,12 @@ The bridge is configured via environment variables in the `.env` file:
 The bridge supports specific commands that can be typed directly into the Mattermost chat:
 
 - **`!stop`**: Immediately cancels the active prompt in the current thread.
+- **`!impersonate <username | user_id>`**: Allows administrators (configured in `ADMIN_USERS`) to operate as other users.
+  - To impersonate: `!impersonate @username` or `!impersonate user_id`.
+  - All subsequent prompts will execute under the target user's context (including Linux user mappings, dynamic configuration overrides, and thread histories).
+  - Prompts will be automatically prepended with `[Sender: @username]` so the agent is aware of who it is interacting with.
+  - Control commands like `!stop` will route directly to the impersonated user's session.
+  - To clear impersonation: `!impersonate clear`, `!impersonate off`, or `!impersonate stop`.
 
 ## 🏃 Usage
 

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,7 @@ class Config:
     mattermost_scheme: str = os.getenv("MATTERMOST_SCHEME", "https")
     mattermost_port: str = os.getenv("MATTERMOST_PORT", "443")
     approved_users: List[str] = None
+    admin_users: List[str] = None
     poll_interval: int = int(os.getenv("POLL_INTERVAL", "1"))
     debug: bool = os.getenv("DEBUG", "false").lower() == "true"
     goose_thinking_trace: bool = os.getenv("GOOSE_THINKING_TRACE",
@@ -45,6 +46,12 @@ class Config:
             self.approved_users = [
                 u.strip()
                 for u in os.getenv("APPROVED_USERS", "").split(",")
+                if u.strip()
+            ]
+        if self.admin_users is None:
+            self.admin_users = [
+                u.strip()
+                for u in os.getenv("ADMIN_USERS", "").split(",")
                 if u.strip()
             ]
         if self.goose_provider is None:
@@ -125,6 +132,7 @@ def load_user_config(linux_user: str, base_config: Config) -> Config:
         "MATTERMOST_SCHEME": ("mattermost_scheme", str),
         "MATTERMOST_PORT": ("mattermost_port", str),
         "APPROVED_USERS": ("approved_users", parse_list),
+        "ADMIN_USERS": ("admin_users", parse_list),
         "POLL_INTERVAL": ("poll_interval", int),
         "DEBUG": ("debug", parse_bool),
         "GOOSE_THINKING_TRACE": ("goose_thinking_trace", parse_bool),

--- a/src/mattermost_bridge.py
+++ b/src/mattermost_bridge.py
@@ -34,6 +34,7 @@ class MattermostBridge:
         self.bot_mention = None
         self.background_tasks = set()
         self.thread_counters = {}  # Track message counts per thread
+        self.impersonations = {}  # Admin impersonation state: admin_id -> {"id": target_id, "username": target_username}
 
     async def initialize(self) -> bool:
         """Initializes the bridge by connecting to Mattermost."""
@@ -81,7 +82,12 @@ class MattermostBridge:
         sender_id = post["user_id"]
         cid = post["channel_id"]
         root_id = post.get("root_id") or post["id"]
-        session_key = get_session_key(sender_id, root_id)
+        
+        eff_id = sender_id
+        if sender_id in self.impersonations:
+            eff_id = self.impersonations[sender_id]["id"]
+            
+        session_key = get_session_key(eff_id, root_id)
 
         interrupted = False
         if session_key in self.sessions:
@@ -89,9 +95,9 @@ class MattermostBridge:
                 f"[{datetime.now()}] Interruption requested for {session_key}")
             sid = self.sessions[session_key]["id"]
             user_mapping = load_user_mapping(self.config.user_mapping_file)
-            user_info = await self.api.get_user(sender_id)
+            user_info = await self.api.get_user(eff_id)
             username = user_info.get("username") if user_info else "unknown"
-            linux_user = user_mapping.get(sender_id) or user_mapping.get(
+            linux_user = user_mapping.get(eff_id) or user_mapping.get(
                 username)
 
             if linux_user and linux_user in self.goose_clients:
@@ -112,7 +118,12 @@ class MattermostBridge:
         sender_id = post["user_id"]
         cid = post["channel_id"]
         root_id = post.get("root_id") or post["id"]
-        session_key = get_session_key(sender_id, root_id)
+        
+        eff_id = sender_id
+        if sender_id in self.impersonations:
+            eff_id = self.impersonations[sender_id]["id"]
+            
+        session_key = get_session_key(eff_id, root_id)
 
         if session_key not in self.sessions:
             await self.api.create_post(
@@ -152,6 +163,91 @@ class MattermostBridge:
         msg += f"- Usage: `{percent:.1f}%`"
 
         await self.api.create_post(cid, msg, root_id=root_id)
+
+    async def _handle_impersonate_command(self, post: dict, cleaned_msg: str):
+        """Handles the !impersonate command for administrators."""
+        sender_id = post["user_id"]
+        cid = post["channel_id"]
+        root_id = post.get("root_id") or post["id"]
+
+        user_info = await self.api.get_user(sender_id)
+        username = user_info.get("username") if user_info else "unknown"
+
+        is_admin = False
+        if self.config.admin_users:
+            if sender_id in self.config.admin_users or username in self.config.admin_users:
+                is_admin = True
+
+        if not is_admin:
+            await self.api.create_post(
+                cid,
+                "⚠️ Permission denied: Only administrators can use the `!impersonate` command.",
+                root_id=root_id
+            )
+            return
+
+        parts = cleaned_msg.split(maxsplit=1)
+        if len(parts) == 1 or parts[1].strip().lower() in ["clear", "off", "stop"]:
+            if sender_id in self.impersonations:
+                old_target = self.impersonations.pop(sender_id)
+                await self.api.create_post(
+                    cid,
+                    f"👤 *Impersonation cleared. You are no longer impersonating @{old_target['username']}.*",
+                    root_id=root_id
+                )
+            else:
+                await self.api.create_post(
+                    cid,
+                    "ℹ️ *You are not currently impersonating any user.*",
+                    root_id=root_id
+                )
+            return
+
+        target = parts[1].strip().lstrip("@")
+        target_user = None
+
+        # 1. Try resolving by user ID
+        target_user = await self.api.get_user(target)
+        if not target_user:
+            # 2. Try searching by username
+            users = await self.api.search_users(target)
+            if users:
+                for u in users:
+                    if u.get("username") == target or u.get("id") == target:
+                        target_user = u
+                        break
+                if not target_user:
+                    target_user = users[0]
+
+        if not target_user:
+            await self.api.create_post(
+                cid,
+                f"⚠️ *Error: User `{target}` could not be found.*",
+                root_id=root_id
+            )
+            return
+
+        target_id = target_user["id"]
+        target_username = target_user["username"]
+
+        if target_id == self.bot_id or target_username == self.bot_username:
+            await self.api.create_post(
+                cid,
+                "⚠️ *Error: You cannot impersonate the bot itself.*",
+                root_id=root_id
+            )
+            return
+
+        self.impersonations[sender_id] = {
+            "id": target_id,
+            "username": target_username
+        }
+
+        await self.api.create_post(
+            cid,
+            f"👤 *You are now impersonating @{target_username} (`{target_id}`). All subsequent prompts will run in their context.*",
+            root_id=root_id
+        )
 
     async def _prune_sessions(self):
         """Prunes old sessions if the count exceeds MAX_SESSIONS."""
@@ -260,9 +356,9 @@ class MattermostBridge:
                                                props=props)
                 last_update_time = current_time
 
-    async def _handle_message(self, post: dict, linux_user: Optional[str], username: str):
+    async def _handle_message(self, post: dict, linux_user: Optional[str], username: str, sender_id: Optional[str] = None):
         """Handles an incoming message from Mattermost."""
-        sender_id = post["user_id"]
+        sender_id = sender_id or post["user_id"]
         message = post.get("message", "").strip()
         if not message:
             return
@@ -292,9 +388,15 @@ class MattermostBridge:
                     message = f"[Has {len(file_ids)} attachment(s)] {message}"
                 message = f"[Sender: @{username}] {message}"
 
-                print(
-                    f"[{datetime.now()}] User {username} ({sender_id}) says: {message[:100]}..."
-                )
+                real_sender_id = post["user_id"]
+                if real_sender_id != sender_id:
+                    print(
+                        f"[{datetime.now()}] Admin ({real_sender_id}) impersonating {username} ({sender_id}) says: {message[:100]}..."
+                    )
+                else:
+                    print(
+                        f"[{datetime.now()}] User {username} ({sender_id}) says: {message[:100]}..."
+                    )
 
                 is_new_session = False
                 if session_key not in self.sessions:
@@ -404,6 +506,13 @@ class MattermostBridge:
         if root_id in self.thread_counters:
             self.thread_counters[root_id] += 1
 
+        cleaned_msg = clean_message(message, self.bot_mention)
+
+        # Special Command: !impersonate
+        if cleaned_msg.lower().startswith("!impersonate"):
+            await self._handle_impersonate_command(post, cleaned_msg)
+            return
+
         # Special Command: !stop
         if message.lower() == "!stop":
             await self._handle_stop_command(post)
@@ -444,13 +553,20 @@ class MattermostBridge:
                     )
                 return
 
+        # Resolve effective sender (impersonation lookup)
+        eff_id = sender_id
+        eff_username = username
+        if sender_id in self.impersonations:
+            eff_id = self.impersonations[sender_id]["id"]
+            eff_username = self.impersonations[sender_id]["username"]
+
         # Linux User Mapping
         user_mapping = load_user_mapping(self.config.user_mapping_file)
-        linux_user = user_mapping.get(sender_id) or user_mapping.get(username)
+        linux_user = user_mapping.get(eff_id) or user_mapping.get(eff_username)
 
         if self.config.require_user_mapping and not linux_user:
             print(
-                f"[{datetime.now()}] Rejecting approved user {username}: No Linux user mapping and REQUIRE_USER_MAPPING=true"
+                f"[{datetime.now()}] Rejecting approved user {eff_username}: No Linux user mapping and REQUIRE_USER_MAPPING=true"
             )
             await self.api.create_post(
                 cid,
@@ -460,7 +576,7 @@ class MattermostBridge:
             return
 
         # Spawn task to handle message
-        task = asyncio.create_task(self._handle_message(post, linux_user, username))
+        task = asyncio.create_task(self._handle_message(post, linux_user, eff_username, sender_id=eff_id))
         self.background_tasks.add(task)
         task.add_done_callback(self.background_tasks.discard)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,11 @@ def test_config_approved_users():
         config = Config(approved_users=None)
         assert config.approved_users == ["user1", "user2"]
 
+def test_config_admin_users():
+    with patch.dict(os.environ, {"ADMIN_USERS": "admin1, admin2"}):
+        config = Config(admin_users=None)
+        assert config.admin_users == ["admin1", "admin2"]
+
 def test_config_initialization():
     config = Config(
         mattermost_url="test.com",

--- a/tests/test_mattermost_bridge.py
+++ b/tests/test_mattermost_bridge.py
@@ -22,6 +22,7 @@ def mock_api():
     api.update_post = AsyncMock()
     api.get_user = AsyncMock(return_value={"username": "user1"})
     api.get_thread = AsyncMock(return_value={"posts": {}})
+    api.search_users = AsyncMock(return_value=[])
     return api
 
 
@@ -949,4 +950,192 @@ async def test_run_keyboard_interrupt_termination_fails(config, mock_api, mock_g
         await bridge.run()
         
     assert mock_process.terminate.called
+
+
+@pytest.mark.asyncio
+async def test_impersonate_command_permission_denied(config, mock_api):
+    config.admin_users = ["admin1"]
+    config.approved_users = []
+    bridge = MattermostBridge(api=mock_api, config=config)
+    bridge.bot_id = "bot_id"
+    bridge.bot_username = "bot"
+    bridge.bot_mention = "@bot"
+    mock_api.get_user = AsyncMock(return_value={"id": "u1", "username": "user1"})
+
+    post = {
+        "id": "p1",
+        "user_id": "u1",
+        "channel_id": "c1",
+        "message": "!impersonate @someuser"
+    }
+    
+    await bridge._process_post(post, {"c1": {"type": "O"}})
+    
+    assert mock_api.create_post.called
+    args, kwargs = mock_api.create_post.call_args
+    assert "Permission denied" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_impersonate_command_user_not_found(config, mock_api):
+    config.admin_users = ["admin1"]
+    config.approved_users = []
+    bridge = MattermostBridge(api=mock_api, config=config)
+    bridge.bot_id = "bot_id"
+    bridge.bot_username = "bot"
+    bridge.bot_mention = "@bot"
+    mock_api.get_user = AsyncMock(side_effect=lambda uid: {"id": "admin1", "username": "admin1"} if uid == "admin1" else None)
+    mock_api.search_users = AsyncMock(return_value=[])
+
+    post = {
+        "id": "p1",
+        "user_id": "admin1",
+        "channel_id": "c1",
+        "message": "!impersonate nonexistentuser"
+    }
+    
+    await bridge._process_post(post, {"c1": {"type": "O"}})
+    
+    assert mock_api.create_post.called
+    args, kwargs = mock_api.create_post.call_args
+    assert "could not be found" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_impersonate_command_bot_self(config, mock_api):
+    config.admin_users = ["admin1"]
+    config.approved_users = []
+    bridge = MattermostBridge(api=mock_api, config=config)
+    bridge.bot_id = "bot_id"
+    bridge.bot_username = "bot"
+    bridge.bot_mention = "@bot"
+    mock_api.get_user = AsyncMock(side_effect=lambda uid: {"id": "admin1", "username": "admin1"} if uid == "admin1" else ({"id": "bot_id", "username": "bot"} if uid == "bot_id" else None))
+    mock_api.search_users = AsyncMock(return_value=[{"id": "bot_id", "username": "bot"}])
+
+    post = {
+        "id": "p1",
+        "user_id": "admin1",
+        "channel_id": "c1",
+        "message": "!impersonate bot"
+    }
+    
+    await bridge._process_post(post, {"c1": {"type": "O"}})
+    
+    assert mock_api.create_post.called
+    args, kwargs = mock_api.create_post.call_args
+    assert "cannot impersonate the bot itself" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_impersonate_command_success_and_cleared(config, mock_api, mock_goose_client):
+    config.admin_users = ["admin1"]
+    config.approved_users = []
+    bridge = MattermostBridge(api=mock_api, config=config, goose_client_factory=lambda u: mock_goose_client)
+    bridge.bot_id = "bot_id"
+    bridge.bot_username = "bot"
+    bridge.bot_mention = "@bot"
+    
+    users_db = {
+        "admin1": {"id": "admin1", "username": "admin1"},
+        "target1": {"id": "target1", "username": "target1"}
+    }
+    mock_api.get_user = AsyncMock(side_effect=lambda uid: users_db.get(uid))
+    mock_api.search_users = AsyncMock(return_value=[{"id": "target1", "username": "target1"}])
+
+    # 1. Start Impersonating
+    post = {
+        "id": "p1",
+        "user_id": "admin1",
+        "channel_id": "c1",
+        "message": "!impersonate @target1"
+    }
+    await bridge._process_post(post, {"c1": {"type": "O"}})
+    assert bridge.impersonations["admin1"] == {"id": "target1", "username": "target1"}
+    
+    assert mock_api.create_post.called
+    args, kwargs = mock_api.create_post.call_args
+    assert "now impersonating @target1" in args[1]
+
+    # 2. Subsequent prompt is handled under effective user
+    mock_api.create_post.reset_mock()
+    msg_post = {
+        "id": "p2",
+        "user_id": "admin1",
+        "channel_id": "c1",
+        "message": "@bot Hello",
+        "root_id": "root1"
+    }
+    
+    with patch('mattermost_bridge.load_user_mapping', return_value={"target1": "target_linux"}):
+        await bridge._process_post(msg_post, {"c1": {"type": "O"}})
+        await wait_for_bridge(bridge)
+        
+        # Session should be key target1:root1
+        assert "target1:root1" in bridge.sessions
+        assert bridge.sessions["target1:root1"]["linux_user"] == "target_linux"
+
+    # 3. Clear Impersonation
+    mock_api.create_post.reset_mock()
+    clear_post = {
+        "id": "p3",
+        "user_id": "admin1",
+        "channel_id": "c1",
+        "message": "!impersonate clear"
+    }
+    await bridge._process_post(clear_post, {"c1": {"type": "O"}})
+    assert "admin1" not in bridge.impersonations
+    args, kwargs = mock_api.create_post.call_args
+    assert "Impersonation cleared" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_impersonate_stop_and_context(config, mock_api, mock_goose_client):
+    config.admin_users = ["admin1"]
+    mock_goose_client.cancel_prompt = AsyncMock(return_value=True)
+    bridge = MattermostBridge(api=mock_api, config=config, goose_client_factory=lambda u: mock_goose_client)
+    bridge.bot_id = "bot_id"
+    bridge.bot_username = "bot"
+    bridge.bot_mention = "@bot"
+    
+    bridge.impersonations["admin1"] = {"id": "target1", "username": "target1"}
+    bridge.sessions["target1:root1"] = {
+        "id": "session_target",
+        "linux_user": "target_linux"
+    }
+    bridge.goose_clients["target_linux"] = mock_goose_client
+    mock_goose_client.context_usage = {"session_target": {"used": 100, "size": 1000}}
+
+    users_db = {
+        "admin1": {"id": "admin1", "username": "admin1"},
+        "target1": {"id": "target1", "username": "target1"}
+    }
+    mock_api.get_user = AsyncMock(side_effect=lambda uid: users_db.get(uid))
+
+    # Test !context under impersonation
+    context_post = {
+        "id": "p1",
+        "user_id": "admin1",
+        "channel_id": "c1",
+        "message": "!context",
+        "root_id": "root1"
+    }
+    await bridge._process_post(context_post, {"c1": {"type": "O"}})
+    assert mock_api.create_post.called
+    args, kwargs = mock_api.create_post.call_args
+    assert "10.0%" in args[1]
+
+    # Test !stop under impersonation
+    mock_api.create_post.reset_mock()
+    stop_post = {
+        "id": "p2",
+        "user_id": "admin1",
+        "channel_id": "c1",
+        "message": "!stop",
+        "root_id": "root1"
+    }
+    with patch('mattermost_bridge.load_user_mapping', return_value={"target1": "target_linux"}):
+        await bridge._process_post(stop_post, {"c1": {"type": "O"}})
+        assert mock_goose_client.cancel_prompt.called
+        assert "cancelled" in mock_api.create_post.call_args[0][1]
+
 


### PR DESCRIPTION
This PR adds the admin impersonation feature to goose-mm-bridge.

### Changes:
- **Config**: Added the `ADMIN_USERS` parameter parsed from environment variables (comma-separated usernames or user IDs). Supports overrides via user-specific `.env` configurations.
- **Mattermost Bridge**:
  - Maintained `self.impersonations` in-memory dictionary.
  - Added the `!impersonate <target>` command to impersonate another user (by ID or username via automated search).
  - Supported clearing active impersonations with `!impersonate clear`, `!impersonate off`, or `!impersonate stop`.
  - Blocked non-administrators from triggering the command.
  - Handled incoming prompts, `!stop`, and `!context` actions under the context of the impersonated user's session key, user mapping, and metadata.
- **Testing**:
  - Added unit tests for parsing `ADMIN_USERS` in `test_config.py`.
  - Added comprehensive unit tests in `test_mattermost_bridge.py` covering permission denial, user search/resolution, target lookup failure, bot impersonation prevention, successful impersonation session flow, stop, and context actions.

Reviewer: @mrazza